### PR TITLE
Fix close of all dialogs after auth guard

### DIFF
--- a/src/app/shared/services/quizee.service.spec.ts
+++ b/src/app/shared/services/quizee.service.spec.ts
@@ -408,7 +408,12 @@ describe('QuizeeService', () => {
     });
 
     it('should close dialog and switch to provided stream when authorized after dialog open', async () => {
-      jest.spyOn(matDialog, 'closeAll');
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(of()),
+        close: jest.fn(),
+      };
+
+      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
 
       (service as any).withAuthGuard(() => of(1, 2, 3)).subscribe({ next, error });
 
@@ -420,7 +425,7 @@ describe('QuizeeService', () => {
       expect(error).not.toBeCalled();
       expect(next).toBeCalledTimes(3);
 
-      expect(matDialog.closeAll).toBeCalledTimes(1);
+      expect(dialogRef.close).toBeCalledTimes(1);
     });
 
     it('should not start provided stream every time auth state changes', async () => {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] Feature
- [ ] Other

## What is the current behavior?
### (You can also link to an open issue here)
Auth guard closes all of the opened dialogs

## What is the new behavior?
Auth guard closes only it's opened dialog if any

## Does this PR introduce a breaking change?
No

## Other information
