### PR TITLE
Introduce mobile editor

### DIFF
--- a/src/app/editor/editor.component.html
+++ b/src/app/editor/editor.component.html
@@ -1,6 +1,6 @@
 <div
   class="loader-container"
-  *ngIf="!(quizeeEditingService.get() | async)"
+  *ngIf="!(quizeeEditingService.getQuizee() | async)"
   @loader
 >
   <div class="loader">
@@ -10,50 +10,143 @@
   </div>
 </div>
 
-<mat-toolbar
-  color="primary"
-  class="header mat-elevation-z6"
+<div
+  fxFlex="100%"
+  fxLayout="column"
+  fxHide.lt-sm
 >
-  <button
-    type="button"
-    mat-icon-button
-    routerLink="/"
-  >
-    <mat-icon>home</mat-icon>
-  </button>
-  <span style="flex: 1 1 auto"></span>
-  <div
-    fxLayout
-    fxLayoutAlign="center center"
-  >
-    <span>{{ (quizeeEditingService.get() | async)?.info?.caption || '' }}</span>
-  </div>
-  <span style="flex: 1 1 auto"></span>
-  <div
-    [matTooltip]="validationError"
-    [matTooltipDisabled]="!validationError"
+  <!-- Wide screen -->
+  <mat-toolbar
+    color="primary"
+    class="header mat-elevation-z6"
   >
     <button
-      mat-flat-button
-      class="animated-flat-button"
-      color="primary"
-      (click)="publish()"
-      [disabled]="!!validationError"
+      type="button"
+      mat-icon-button
+      routerLink="/"
     >
-      <mat-icon>publish</mat-icon> Publish
+      <mat-icon>home</mat-icon>
     </button>
+    <span style="flex: 1 1 auto"></span>
+    <div
+      fxLayout
+      fxLayoutAlign="center center"
+    >
+      <span>{{ (quizeeEditingService.getQuizee() | async)?.info?.caption || '' }}</span>
+    </div>
+    <span style="flex: 1 1 auto"></span>
+    <div
+      [matTooltip]="validationError"
+      [matTooltipDisabled]="!validationError"
+    >
+      <button
+        mat-flat-button
+        class="animated-flat-button"
+        color="primary"
+        (click)="publish()"
+        [disabled]="!!validationError"
+      >
+        <mat-icon>publish</mat-icon> Publish
+      </button>
+    </div>
+  </mat-toolbar>
+  <div class="editor-container">
+    <div
+      fxLayout="row"
+      fxFlex
+    >
+      <div
+        fxLayout="column"
+        [fxFlex.lt-md]="(100 / 12) * 5 + '%'"
+        [fxFlex.lt-lg]="(100 / 12) * 4 + '%'"
+        [fxFlex]="(100 / 12) * 2 + '%'"
+      >
+        <mat-card class="mat-elevation-z2 full-width-card">
+          <mat-form-field fxFlex="100%">
+            <mat-label>Quizee name</mat-label>
+            <input
+              matInput
+              [formControl]="quizeeName"
+            />
+            <mat-error *ngIf="quizeeName.hasError('string.empty')">Quizee name shouldn't be empty </mat-error>
+          </mat-form-field>
+        </mat-card>
+        <app-overview
+          #questionsContainer
+          fxFlex="grow"
+          style="overflow-y: scroll"
+        ></app-overview>
+        <mat-card class="mat-elevation-z2 mat-reverse-elevation full-width-card">
+          <button
+            mat-stroked-button
+            color="primary"
+            fxFlex
+            (click)="handleQuestionCreation()"
+          >
+            <mat-icon>add</mat-icon>
+          </button>
+        </mat-card>
+      </div>
+      <mat-divider [vertical]="true"></mat-divider>
+      <div
+        fxLayout="column"
+        fxFlex
+        fxGrow="1"
+        fxShrink="1"
+        fxHide.lt-md
+      >
+        <app-question-screen></app-question-screen>
+      </div>
+      <mat-divider [vertical]="true"></mat-divider>
+      <app-settings
+        style="overflow-y: scroll"
+        fxLayout="column"
+        [fxFlex.lt-md]="(100 / 12) * 7 + '%'"
+        [fxFlex.lt-lg]="(100 / 12) * 5 + '%'"
+        [fxFlex]="(100 / 12) * 3 + '%'"
+      ></app-settings>
+    </div>
   </div>
-</mat-toolbar>
-<div class="editor-container">
-  <div
-    fxLayout="row"
-    fxFlex
+</div>
+
+<div
+  fxFlex="100%"
+  fxLayout="column"
+  fxHide.gt-xs
+>
+  <!-- Narrow screen -->
+  <mat-toolbar
+    color="primary"
+    class="header mat-elevation-z6"
   >
+    <button
+      type="button"
+      mat-icon-button
+      routerLink="/"
+    >
+      <mat-icon>home</mat-icon>
+    </button>
+    <span style="flex: 1 1 auto"></span>
+    <div
+      [matTooltip]="validationError"
+      [matTooltipDisabled]="!validationError"
+    >
+      <button
+        mat-flat-button
+        class="animated-flat-button"
+        color="primary"
+        (click)="publish()"
+        [disabled]="!!validationError"
+      >
+        <mat-icon>publish</mat-icon> Publish
+      </button>
+    </div>
+  </mat-toolbar>
+
+  <div class="editor-container">
     <div
       fxLayout="column"
-      [fxFlex.lt-md]="(100 / 12) * 5 + '%'"
-      [fxFlex.lt-lg]="(100 / 12) * 4 + '%'"
-      [fxFlex]="(100 / 12) * 2 + '%'"
+      fxFlexFill
     >
       <mat-card class="mat-elevation-z2 full-width-card">
         <mat-form-field fxFlex="100%">
@@ -67,8 +160,8 @@
       </mat-card>
       <app-overview
         #questionsContainer
+        [useExpansionPanel]="true"
         fxFlex="grow"
-        style="overflow-y: scroll"
       ></app-overview>
       <mat-card class="mat-elevation-z2 mat-reverse-elevation full-width-card">
         <button
@@ -81,23 +174,5 @@
         </button>
       </mat-card>
     </div>
-    <mat-divider [vertical]="true"></mat-divider>
-    <div
-      fxLayout="column"
-      fxFlex
-      fxGrow="1"
-      fxShrink="1"
-      fxHide.lt-md="true"
-    >
-      <app-question-screen></app-question-screen>
-    </div>
-    <mat-divider [vertical]="true"></mat-divider>
-    <app-settings
-      style="overflow-y: scroll"
-      fxLayout="column"
-      [fxFlex.lt-md]="(100 / 12) * 7 + '%'"
-      [fxFlex.lt-lg]="(100 / 12) * 5 + '%'"
-      [fxFlex]="(100 / 12) * 3 + '%'"
-    ></app-settings>
   </div>
 </div>

--- a/src/app/editor/editor.component.scss
+++ b/src/app/editor/editor.component.scss
@@ -2,6 +2,7 @@
 
 :host {
   display: flex;
+  position: relative;
   flex-direction: column;
   height: 100%;
 }

--- a/src/app/editor/editor.component.spec.ts
+++ b/src/app/editor/editor.component.spec.ts
@@ -42,7 +42,7 @@ describe('EditorComponent', () => {
     quizeeEditingService = new QuizeeEditingService() as any;
     fakePlayerService = new FakePlayerService() as any;
 
-    quizeeEditingService.get.mockReturnValue(of());
+    quizeeEditingService.getQuizee.mockReturnValue(of());
     quizeeEditingService.getQuizeeErrors.mockReturnValue(of([]));
     quizeeEditingService.getCurrentQuestion.mockReturnValue(of());
     fakePlayerService.loadQuestion.mockReturnValue(of(0 as any /* to suppress undefined error */));
@@ -86,7 +86,7 @@ describe('EditorComponent', () => {
         id: idVal,
       };
 
-      const load = jest.spyOn(quizeeEditingService, 'load');
+      const load = jest.spyOn(quizeeEditingService, 'loadQuizee');
 
       const quizObj = { [Symbol()]: 1 };
       jest.spyOn(quizeeService, 'getFullQuizee').mockReturnValue(of(quizObj) as any);
@@ -101,7 +101,7 @@ describe('EditorComponent', () => {
       activatedRoute.paramMapValues = {
         id: null,
       };
-      const create = jest.spyOn(quizeeEditingService, 'create');
+      const create = jest.spyOn(quizeeEditingService, 'createQuizee');
 
       component.ngOnInit();
 
@@ -176,7 +176,7 @@ describe('EditorComponent', () => {
     it('should unsubscribe', async () => {
       const subject = new Subject();
 
-      quizeeEditingService.get.mockReturnValue(subject as any);
+      quizeeEditingService.getQuizee.mockReturnValue(subject as any);
       activatedRoute.paramMap = subject as any;
       (component.quizeeName as any).valueChanges = subject as any;
       quizeeEditingService.getCurrentQuestion.mockReturnValue(subject as any);
@@ -277,15 +277,15 @@ describe('EditorComponent', () => {
 
         await jest.runAllTimers();
 
-        expect(quizeeEditingService.modify).toHaveBeenCalledTimes(1);
-        expect(quizeeEditingService.modify).toHaveBeenCalledWith({ info: { caption: 'abc123' } });
+        expect(quizeeEditingService.modifyQuizee).toHaveBeenCalledTimes(1);
+        expect(quizeeEditingService.modifyQuizee).toHaveBeenCalledWith({ info: { caption: 'abc123' } });
       });
     });
 
     describe('question type value change', () => {
       it('should update input value if its value differs', async () => {
         const subject = new Subject();
-        const getCurrentQuestion = jest.spyOn(quizeeEditingService, 'get');
+        const getCurrentQuestion = jest.spyOn(quizeeEditingService, 'getQuizee');
         getCurrentQuestion.mockReturnValue(subject as any);
 
         const setValue = jest.spyOn(component.quizeeName, 'setValue');
@@ -304,7 +304,7 @@ describe('EditorComponent', () => {
 
       it('should not update input value if it is the same', async () => {
         const subject = new Subject();
-        const getCurrentQuestion = jest.spyOn(quizeeEditingService, 'get');
+        const getCurrentQuestion = jest.spyOn(quizeeEditingService, 'getQuizee');
         getCurrentQuestion.mockReturnValue(subject as any);
 
         const setValue = jest.spyOn(component.quizeeName, 'setValue');

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -52,7 +52,7 @@ export class EditorComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.subs.add(
       this.quizeeEditingService
-        .get()
+        .getQuizee()
         .pipe(filter((quizee) => this.quizeeName.value !== quizee.info.caption))
         .subscribe((quizee) => {
           this.quizeeName.setValue(quizee.info.caption);
@@ -72,7 +72,7 @@ export class EditorComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      this.quizeeName.valueChanges.subscribe((v) => this.quizeeEditingService.modify({ info: { caption: v } }))
+      this.quizeeName.valueChanges.subscribe((v) => this.quizeeEditingService.modifyQuizee({ info: { caption: v } }))
     );
 
     this.subs.add(
@@ -82,7 +82,7 @@ export class EditorComponent implements OnInit, OnDestroy {
         if (id?.trim()) {
           this.quizeeService.getFullQuizee(id).subscribe({
             next: (value) => {
-              this.quizeeEditingService.load(value);
+              this.quizeeEditingService.loadQuizee(value);
             },
             error: (_) => {
               this.dialog
@@ -94,7 +94,7 @@ export class EditorComponent implements OnInit, OnDestroy {
             },
           });
         } else {
-          this.quizeeEditingService.create();
+          this.quizeeEditingService.createQuizee();
         }
       })
     );

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -7,6 +7,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -76,6 +77,7 @@ import { SettingsComponent } from './settings/settings.component';
     MatDialogModule,
     MatStepperModule,
     PlayerModule,
+    MatExpansionModule,
   ],
   providers: [
     QuizeeEditingService,

--- a/src/app/editor/overview/overview.component.html
+++ b/src/app/editor/overview/overview.component.html
@@ -1,29 +1,116 @@
-<mat-card
-  @card
-  *ngFor="let question of (quizeeEditingService.get() | async)?.questions || []; let index = index; trackBy: trackBy"
-  class="card"
-  [class.active]="(quizeeEditingService.getCurrentQuestion() | async)?.question?.id === question.id"
-  (click)="quizeeEditingService.selectQuestion(index)"
+<ng-container [ngTemplateOutlet]="useExpansionPanel ? expansionPanel : card"></ng-container>
+
+<ng-template #card>
+  <mat-card
+    @card
+    class="card"
+    *ngFor="
+      let question of (quizeeEditingService.getQuizee() | async)?.questions || [];
+      let index = index;
+      trackBy: trackBy
+    "
+    (click)="quizeeEditingService.selectQuestion(index)"
+    [class.active]="(quizeeEditingService.getCurrentQuestion() | async)?.question?.id === question.id"
+  >
+    <div class="preview-container">
+      <mat-icon
+        class="preview-icon"
+        color="primary"
+      >
+        <ng-container
+          [ngTemplateOutlet]="questionIconName"
+          [ngTemplateOutletContext]="{ question: question }"
+        ></ng-container>
+      </mat-icon>
+      <h3>
+        <ng-container
+          [ngTemplateOutlet]="previewText"
+          [ngTemplateOutletContext]="{ question: question }"
+        ></ng-container>
+      </h3>
+    </div>
+    <ng-container
+      [ngTemplateOutlet]="errorBadge"
+      [ngTemplateOutletContext]="{ index: index }"
+    ></ng-container>
+  </mat-card>
+</ng-template>
+
+<ng-template
+  #expansionPanel
+  let-index="index"
+  let-question="question"
+  let-active="active"
 >
-  <div class="preview-container">
-    <mat-icon
-      class="preview-icon"
-      color="primary"
+  <mat-accordion>
+    <mat-expansion-panel
+      *ngFor="
+        let question of (quizeeEditingService.getQuizee() | async)?.questions || [];
+        let index = index;
+        trackBy: trackBy
+      "
+      (click)="quizeeEditingService.selectQuestion(index)"
+      [expanded]="(quizeeEditingService.getCurrentQuestion() | async)?.question?.id === question.id"
     >
-      <ng-container [ngSwitch]="question.type">
-        <ng-container *ngSwitchCase="'ONE_TRUE'"> done </ng-container>
-        <ng-container *ngSwitchCase="'SEVERAL_TRUE'"> done_all </ng-container>
-        <ng-container *ngSwitchCase="'WRITE_ANSWER'"> edit </ng-container>
-      </ng-container>
-    </mat-icon>
-    <h3>
-      <ng-container [ngSwitch]="question.type">
-        <ng-container *ngSwitchCase="'ONE_TRUE'"> One True </ng-container>
-        <ng-container *ngSwitchCase="'SEVERAL_TRUE'"> Several True </ng-container>
-        <ng-container *ngSwitchCase="'WRITE_ANSWER'"> Write Answer </ng-container>
-      </ng-container>
-    </h3>
-  </div>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon
+            color="primary"
+            [style.marginRight]="'.5rem'"
+          >
+            <ng-container
+              [ngTemplateOutlet]="questionIconName"
+              [ngTemplateOutletContext]="{ question: question }"
+            ></ng-container
+          ></mat-icon>
+          <span>
+            <ng-container
+              [ngTemplateOutlet]="previewText"
+              [ngTemplateOutletContext]="{ question: question }"
+            ></ng-container>
+          </span>
+          <span style="flex-grow: 1; flex-wrap: 1"> </span>
+          <span style="display: flex; align-items: center">
+            <ng-container
+              [ngTemplateOutlet]="errorBadge"
+              [ngTemplateOutletContext]="{ index: index }"
+            ></ng-container>
+          </span>
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <app-settings [questionIndex]="index"></app-settings>
+      </ng-template>
+    </mat-expansion-panel>
+  </mat-accordion>
+</ng-template>
+
+<ng-template
+  #questionIconName
+  let-question="question"
+>
+  <ng-container [ngSwitch]="question.type">
+    <ng-container *ngSwitchCase="'ONE_TRUE'"> done </ng-container>
+    <ng-container *ngSwitchCase="'SEVERAL_TRUE'"> done_all </ng-container>
+    <ng-container *ngSwitchCase="'WRITE_ANSWER'"> edit </ng-container>
+  </ng-container>
+</ng-template>
+
+<ng-template
+  #previewText
+  let-question="question"
+>
+  <ng-container [ngSwitch]="question.type">
+    <ng-container *ngSwitchCase="'ONE_TRUE'"> One True </ng-container>
+    <ng-container *ngSwitchCase="'SEVERAL_TRUE'"> Several True </ng-container>
+    <ng-container *ngSwitchCase="'WRITE_ANSWER'"> Write Answer </ng-container>
+  </ng-container>
+</ng-template>
+
+<ng-template
+  #errorBadge
+  let-index="index"
+>
   <mat-icon
     color="warn"
     class="error-badge"
@@ -32,5 +119,5 @@
     @errorBadge
     *ngIf="hasError(index)"
     >error</mat-icon
-  >
-</mat-card>
+  ></ng-template
+>

--- a/src/app/editor/overview/overview.component.scss
+++ b/src/app/editor/overview/overview.component.scss
@@ -1,5 +1,9 @@
 @use '@angular/material' as mat;
 
+:host {
+  overflow-y: scroll;
+}
+
 .card {
   margin: 0.5rem;
   aspect-ratio: 16 / 9;

--- a/src/app/editor/overview/overview.component.ts
+++ b/src/app/editor/overview/overview.component.ts
@@ -1,5 +1,5 @@
 import { animate, style, transition, trigger } from '@angular/animations';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Question } from '@di-strix/quizee-types';
 import { VerificationErrors } from '@di-strix/quizee-verification-functions';
 
@@ -27,6 +27,8 @@ import { QuizeeValidators } from '../quizee-validators';
   ],
 })
 export class OverviewComponent implements OnInit, OnDestroy {
+  @Input() useExpansionPanel: boolean = false;
+
   errors: VerificationErrors = [];
 
   subs = new Subscription();

--- a/src/app/editor/publish-dialog/publish-dialog.component.html
+++ b/src/app/editor/publish-dialog/publish-dialog.component.html
@@ -57,7 +57,8 @@
       </ng-template>
 
       <div
-        fxLayout="row"
+        fxLayout.gt-sm="row"
+        fxLayout.lt-md="column"
         fxLayoutGap=".5rem"
       >
         <button

--- a/src/app/editor/publish-dialog/publish-dialog.component.spec.ts
+++ b/src/app/editor/publish-dialog/publish-dialog.component.spec.ts
@@ -26,7 +26,7 @@ describe('PublishDialogComponent', () => {
     component.stepper = stepper;
 
     quizeeEditingService.getQuizeeErrors.mockReturnValue(new Subject());
-    quizeeEditingService.get.mockReturnValue(new Subject());
+    quizeeEditingService.getQuizee.mockReturnValue(new Subject());
     quizeeService.publishQuizee.mockReturnValue(new Subject());
 
     stepper.selectedIndex = 0;
@@ -65,12 +65,12 @@ describe('PublishDialogComponent', () => {
 
       await jest.runAllTimers();
 
-      expect(quizeeEditingService.get).toBeCalledTimes(1);
+      expect(quizeeEditingService.getQuizee).toBeCalledTimes(1);
     });
 
     it('should switch to the publish step when got quizee', async () => {
       quizeeEditingService.getQuizeeErrors.mockReturnValue(of([]));
-      quizeeEditingService.get.mockReturnValue(of({} as any));
+      quizeeEditingService.getQuizee.mockReturnValue(of({} as any));
 
       component.ngOnInit();
 
@@ -83,7 +83,7 @@ describe('PublishDialogComponent', () => {
       jest.spyOn(console, 'error').mockImplementation(() => {});
 
       quizeeEditingService.getQuizeeErrors.mockReturnValue(of([]));
-      quizeeEditingService.get.mockReturnValue(of({} as any));
+      quizeeEditingService.getQuizee.mockReturnValue(of({} as any));
       quizeeService.publishQuizee.mockReturnValue(throwError(() => new Error('Mock error')));
 
       component.ngOnInit();
@@ -101,7 +101,7 @@ describe('PublishDialogComponent', () => {
       const mockId = 'mockId';
 
       quizeeEditingService.getQuizeeErrors.mockReturnValue(of([]));
-      quizeeEditingService.get.mockReturnValue(of({} as any));
+      quizeeEditingService.getQuizee.mockReturnValue(of({} as any));
       quizeeService.publishQuizee.mockReturnValue(of({ quizId: mockId }));
 
       component.ngOnInit();

--- a/src/app/editor/publish-dialog/publish-dialog.component.ts
+++ b/src/app/editor/publish-dialog/publish-dialog.component.ts
@@ -42,7 +42,7 @@ export class PublishDialogComponent implements OnInit {
 
           this.stepperState.validation.done = true;
 
-          return this.quizeeEditingService.get();
+          return this.quizeeEditingService.getQuizee();
         }),
         delay(750),
         tap(() => this.switchStepper()),

--- a/src/app/editor/quizee-editing.service.spec.ts
+++ b/src/app/editor/quizee-editing.service.spec.ts
@@ -2,7 +2,7 @@ import { AnswerOption, AnswerOptionId, Quiz } from '@di-strix/quizee-types';
 import { verifyAnswer, verifyQuestion, verifyQuizee } from '@di-strix/quizee-verification-functions';
 
 import * as _ from 'lodash';
-import { Observable, first } from 'rxjs';
+import { Subject, first, skip } from 'rxjs';
 
 import { RecursivePartial } from '../shared/helpers/RecursivePartial';
 
@@ -26,49 +26,167 @@ describe('QuizeeEditingService', () => {
     jest.useFakeTimers();
   });
 
+  describe('set quizee', () => {
+    it('should set quizee and emit it', async () => {
+      const next = jest.spyOn(service.quizee$, 'next');
+
+      service.quizee = '123' as any;
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith('123');
+      expect(service.quizee).toBe('123');
+    });
+
+    it('should not set quizee and emit it if it is falsy', async () => {
+      const next = jest.spyOn(service.quizee$, 'next');
+
+      service.quizee = '' as any;
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(service.quizee).not.toBe('');
+    });
+  });
+
+  describe('set currentQuestionIndex', () => {
+    it('should set and emit index', async () => {
+      const next = jest.spyOn(service.currentQuestionIndex$, 'next');
+
+      service.currentQuestionIndex = 5 as any;
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(5);
+      expect(service.currentQuestionIndex).toBe(5);
+    });
+
+    it('should not emit index if it is the same', async () => {
+      const next = jest.spyOn(service.currentQuestionIndex$, 'next');
+
+      service.currentQuestionIndex = 2 as any;
+      service.currentQuestionIndex = 2 as any;
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+    });
+
+    it('should not set and emit index if it is negative', async () => {
+      const next = jest.spyOn(service.currentQuestionIndex$, 'next');
+
+      service.currentQuestionIndex = 2 as any;
+      service.currentQuestionIndex = -1 as any;
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(2);
+      expect(service.currentQuestionIndex).toBe(2);
+    });
+  });
+
+  describe('currentQuestionIndex', () => {
+    it('should return -1 if question is not created or loaded', () => {
+      expect(service.currentQuestionIndex).toEqual(-1);
+    });
+
+    it('should return proper index', () => {
+      service.createQuizee();
+
+      expect(service.currentQuestionIndex).toEqual(0);
+
+      service.createQuestion();
+      service.createQuestion();
+
+      service.selectQuestion(1);
+
+      expect(service.currentQuestionIndex).toEqual(1);
+
+      service.selectQuestion(0);
+
+      expect(service.currentQuestionIndex).toEqual(0);
+    });
+  });
+
   describe('getQuizeeErrors', () => {
+    it('should not emit if quizee is not loaded', async () => {
+      const complete = jest.fn();
+
+      (verifyQuizee as jest.Mock).mockReturnValue([{}]);
+
+      service.getQuizeeErrors().subscribe({ next, error, complete });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
     it('should call verifier only once per emit', async () => {
       (verifyQuizee as jest.Mock).mockReturnValue([{}]);
 
-      service.create();
+      service.createQuizee();
       service.getQuizeeErrors().subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(verifyQuizee).toHaveBeenCalledTimes(1);
+      expect(verifyQuizee).toBeCalledTimes(1);
       expect(next).toBeCalledTimes(1);
-      expect(error).not.toHaveBeenCalled();
+      expect(error).not.toBeCalled();
     });
 
     it('should emit exact value to subscriber', async () => {
       const result = { a: 1, b: 2 };
       (verifyQuizee as jest.Mock).mockReturnValue([result]);
 
-      service.create();
+      service.createQuizee();
       service.getQuizeeErrors().subscribe({ next, error });
 
       await jest.runAllTimers();
 
       expect(next).toBeCalledTimes(1);
       expect(next).toBeCalledWith(result);
-      expect(error).not.toHaveBeenCalled();
+      expect(error).not.toBeCalled();
     });
   });
 
   describe('getCurrentQuestionErrors', () => {
+    it('should not emit if quizee is not loaded', async () => {
+      const complete = jest.fn();
+
+      (verifyQuizee as jest.Mock).mockReturnValue([{}]);
+
+      service.getCurrentQuestionErrors().subscribe({ next, error, complete });
+      service.currentQuestionIndex$.next(0);
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
     it('should call verifiers only once per emit', async () => {
       (verifyQuestion as jest.Mock).mockReturnValue([{}]);
       (verifyAnswer as jest.Mock).mockReturnValue([{}]);
 
+      service.createQuizee();
+      service.currentQuestionIndex$ = new Subject() as any;
+
       service.getCurrentQuestionErrors().subscribe({ next, error });
-      service.currentQuestion$.next({} as any);
+      service.currentQuestionIndex$.next(0);
 
       await jest.runAllTimers();
 
-      expect(verifyQuestion).toHaveBeenCalledTimes(1);
-      expect(verifyAnswer).toHaveBeenCalledTimes(1);
+      expect(verifyQuestion).toBeCalledTimes(1);
+      expect(verifyAnswer).toBeCalledTimes(1);
       expect(next).toBeCalledTimes(1);
-      expect(error).not.toHaveBeenCalled();
+      expect(error).not.toBeCalled();
     });
 
     it('should combine values from verifiers', async () => {
@@ -79,52 +197,83 @@ describe('QuizeeEditingService', () => {
       (verifyQuestion as jest.Mock).mockReturnValue([vq]);
       (verifyAnswer as jest.Mock).mockReturnValue([va]);
 
+      service.createQuizee();
       service.getCurrentQuestionErrors().subscribe({ next, error });
-      service.currentQuestion$.next({} as any);
 
       await jest.runAllTimers();
 
       expect(next).toBeCalledTimes(1);
       expect(next).toBeCalledWith(res);
-      expect(error).not.toHaveBeenCalled();
+      expect(error).not.toBeCalled();
     });
   });
 
-  describe('create', () => {
-    it('should create new quiz and return observable that emits new quizee', async () => {
-      service.create().subscribe({ next, error });
+  describe('getQuestionErrors', () => {
+    it('should not emit if quizee is not loaded', async () => {
+      const complete = jest.fn();
+
+      (verifyQuizee as jest.Mock).mockReturnValue([{}]);
+
+      service.getQuestionErrors(0).subscribe({ next, error, complete });
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalled();
-      expect(next.mock.calls[0][0]).toBeTruthy();
-      expect(error).not.toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
     });
 
-    it('should create quizee with initial answer and question', async () => {
-      service.create().subscribe({ next, error });
+    it('should throw if index is out of range', async () => {
+      (verifyQuizee as jest.Mock).mockReturnValue([{}]);
+
+      service.createQuizee();
+      service.getQuestionErrors(1).pipe(skip(1)).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalled();
-      expect(next.mock.calls[0][0].answers.length).toEqual(1);
-      expect(next.mock.calls[0][0].questions.length).toEqual(1);
-      expect(next.mock.calls[0][0].info.questionsCount).toEqual(1);
-      expect(error).not.toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalledTimes(1);
     });
 
-    it('should create valid quiz', async () => {
-      const { verifyQuizee } = jest.requireActual('@di-strix/quizee-verification-functions');
+    it('should call verifiers only once per emit', async () => {
+      (verifyQuestion as jest.Mock).mockReturnValue([{}]);
+      (verifyAnswer as jest.Mock).mockReturnValue([{}]);
 
-      service.create().subscribe({ next, error });
+      service.createQuizee();
+      service.quizee$ = new Subject() as any;
+
+      service.getQuestionErrors(0).subscribe({ next, error });
+      service.quizee$.next(service.quizee as any);
 
       await jest.runAllTimers();
 
-      expect(await verifyQuizee(next.mock.calls[0][0])).toEqual([]);
+      expect(verifyQuestion).toBeCalledTimes(1);
+      expect(verifyAnswer).toBeCalledTimes(1);
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should combine values from verifiers', async () => {
+      const vq = { a: 1, b: 2 };
+      const va = { a: 2, b: 3 };
+      const res = { answer: va, question: vq };
+
+      (verifyQuestion as jest.Mock).mockReturnValue([vq]);
+      (verifyAnswer as jest.Mock).mockReturnValue([va]);
+
+      service.createQuizee();
+      service.getQuestionErrors(0).pipe(skip(1)).subscribe({ next, error });
+      service.setCurrentQuestionAnswer(['1']);
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(res);
+      expect(error).not.toBeCalled();
     });
   });
 
-  describe('load', () => {
+  describe('loadQuizee', () => {
     it('should load provided quiz and return observable that emits loaded quizee', async () => {
       const quizee: RecursivePartial<Quiz> = {
         [Symbol()]: 'data',
@@ -132,12 +281,12 @@ describe('QuizeeEditingService', () => {
         answers: [{}],
       };
 
-      service.load(quizee as any as Quiz).subscribe({ next, error });
+      service.loadQuizee(quizee as any as Quiz).subscribe({ next, error });
 
       await jest.runAllTimers();
 
       expect(next).toHaveBeenCalledWith(quizee);
-      expect(error).not.toHaveBeenCalled();
+      expect(error).not.toBeCalled();
     });
 
     it('should make sure that length of questions and answers is equal', async () => {
@@ -147,12 +296,12 @@ describe('QuizeeEditingService', () => {
         answers: [{}],
       };
 
-      service.load(quizee as any as Quiz).subscribe({ next, error });
+      service.loadQuizee(quizee as any as Quiz).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
 
       next.mockReset();
       error.mockReset();
@@ -160,14 +309,14 @@ describe('QuizeeEditingService', () => {
       quizee.questions?.pop();
 
       service
-        .load(quizee as any as Quiz)
+        .loadQuizee(quizee as any as Quiz)
         .pipe(first())
         .subscribe({ next, error });
 
       await jest.runAllTimers();
 
       expect(next).toHaveBeenCalledWith(quizee);
-      expect(error).not.toHaveBeenCalled();
+      expect(error).not.toBeCalled();
     });
 
     it('should check whether quizee contains at least one question', async () => {
@@ -177,23 +326,57 @@ describe('QuizeeEditingService', () => {
         answers: [],
       };
 
-      service.load(quizee as any as Quiz).subscribe({ next, error });
+      service.loadQuizee(quizee as any as Quiz).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
   });
 
-  describe('modify', () => {
-    it("should throw if quizee isn't created", async () => {
-      service.modify({}).subscribe({ next, error });
+  describe('createQuizee', () => {
+    it('should create new quiz and return observable that emits new quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).toBeCalled();
+      expect(next.mock.calls[0][0]).toBeTruthy();
+      expect(error).not.toBeCalled();
+    });
+
+    it('should create quizee with initial answer and question', async () => {
+      service.createQuizee().subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalled();
+      expect(next.mock.calls[0][0].answers.length).toEqual(1);
+      expect(next.mock.calls[0][0].questions.length).toEqual(1);
+      expect(next.mock.calls[0][0].info.questionsCount).toEqual(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should create valid quiz', async () => {
+      const { verifyQuizee } = jest.requireActual('@di-strix/quizee-verification-functions');
+
+      service.createQuizee().subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(await verifyQuizee(next.mock.calls[0][0])).toEqual([]);
+    });
+  });
+
+  describe('modifyQuizee', () => {
+    it("should throw if quizee isn't created", async () => {
+      service.modifyQuizee({}).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
 
     it('should concat current quizee with the provided changes', async () => {
@@ -205,14 +388,14 @@ describe('QuizeeEditingService', () => {
         change2: 'change2',
       };
 
-      service.create().subscribe({ next, error });
-      service.modify(change1 as any as Quiz);
-      service.modify(change2 as any as Quiz);
+      service.createQuizee().subscribe({ next, error });
+      service.modifyQuizee(change1 as any as Quiz);
+      service.modifyQuizee(change2 as any as Quiz);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(3);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
       expect(next.mock.calls[1][0]).toEqual({ ...next.mock.calls[0][0], ...change1 });
       expect(next.mock.calls[2][0]).toEqual({ ...next.mock.calls[1][0], ...change2 });
     });
@@ -230,35 +413,35 @@ describe('QuizeeEditingService', () => {
         c: 'change2',
       };
 
-      service.load(quizee as any as Quiz).subscribe({ next, error });
-      service.modify(change1 as any as Quiz);
-      service.modify(change2 as any as Quiz);
+      service.loadQuizee(quizee as any as Quiz).subscribe({ next, error });
+      service.modifyQuizee(change1 as any as Quiz);
+      service.modifyQuizee(change2 as any as Quiz);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(3);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
       expect(next.mock.calls[0][0]).toEqual(quizee);
       expect(next.mock.calls[1][0]).toEqual({ ...next.mock.calls[0][0], ...change1 });
       expect(next.mock.calls[2][0]).toEqual({ ...next.mock.calls[1][0], ...change2 });
     });
 
     it('should not change selected question', async () => {
-      service.create();
+      service.createQuizee();
       service.createQuestion();
       service.createQuestion().subscribe({ next, error });
-      const index = service.getCurrentQuestionIndex();
-      service.modify({ info: { caption: 'aaa' } });
+      const index = service.currentQuestionIndex;
+      service.modifyQuizee({ info: { caption: 'aaa' } });
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(1);
-      expect(service.getCurrentQuestionIndex()).toEqual(index);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(1);
+      expect(service.currentQuestionIndex).toEqual(index);
     });
   });
 
-  describe('get', () => {
+  describe('getQuizee', () => {
     it('should return observable that emits current quizee', async () => {
       const quizee = {
         [Symbol()]: 'data',
@@ -266,13 +449,31 @@ describe('QuizeeEditingService', () => {
         answers: [{}],
       };
 
-      service.load(quizee as any as Quiz);
-      service.get().subscribe({ next, error });
+      service.loadQuizee(quizee as any as Quiz);
+      service.getQuizee().subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalled();
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalled();
+      expect(next.mock.calls[0][0]).toEqual(quizee);
+    });
+
+    it('should not emit if data is the same', async () => {
+      const quizee = {
+        [Symbol()]: 'data',
+        questions: [{}],
+        answers: [{}],
+      };
+
+      service.quizee$.next(quizee as any as Quiz);
+      service.getQuizee().subscribe({ next, error });
+      service.quizee$.next(quizee as any as Quiz);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalled();
       expect(next.mock.calls[0][0]).toEqual(quizee);
     });
   });
@@ -283,35 +484,36 @@ describe('QuizeeEditingService', () => {
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
 
     it('should push updated quizee', async () => {
-      service.create().subscribe({ next, error });
+      service.createQuizee().subscribe({ next, error });
       service.createQuestion();
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(2);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
       expect(next.mock.calls[0]).not.toEqual(next.mock.calls[1]);
     });
 
-    it('should select created question', async () => {
-      service.create();
+    it('should observe created question', async () => {
+      service.createQuizee();
       service.createQuestion().subscribe({ next, error });
+      service.modifyQuestion(1, { question: { type: 'SEVERAL_TRUE' } });
       service.createQuestion();
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(2);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
       expect(next.mock.calls[0]).not.toEqual(next.mock.calls[1]);
     });
 
     it('should create question with initial answer and answerOption', async () => {
-      service.create();
+      service.createQuizee();
       service.createQuestion().subscribe({ next, error });
 
       await jest.runAllTimers();
@@ -322,7 +524,7 @@ describe('QuizeeEditingService', () => {
     });
 
     it('should increment question count', async () => {
-      service.create().subscribe({ next, error });
+      service.createQuizee().subscribe({ next, error });
       service.createQuestion();
 
       await jest.runAllTimers();
@@ -333,7 +535,7 @@ describe('QuizeeEditingService', () => {
     it('should create valid question', async () => {
       const { verifyQuestion, verifyAnswer } = jest.requireActual('@di-strix/quizee-verification-functions');
 
-      service.create();
+      service.createQuizee();
       service.createQuestion().subscribe({ next, error });
 
       await jest.runAllTimers();
@@ -343,59 +545,14 @@ describe('QuizeeEditingService', () => {
     });
   });
 
-  describe('selectQuestion', () => {
-    it('should throw if quizee is not loaded', async () => {
-      service.selectQuestion(0).subscribe({ next, error });
-
-      await jest.runAllTimers();
-
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
-    });
-
-    it('should throw if out of range', async () => {
-      service.create();
-      service.selectQuestion(1).subscribe({ next, error });
-
-      await jest.runAllTimers();
-
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
-    });
-
-    it('should throw if invalid index', async () => {
-      service.create();
-      service.selectQuestion(-1).subscribe({ next, error });
-
-      await jest.runAllTimers();
-
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
-    });
-
-    it('should push current question', async () => {
-      service.create();
-      service.createQuestion();
-      service.createQuestion();
-      service.selectQuestion(0).subscribe({ next, error });
-      service.selectQuestion(1);
-
-      await jest.runAllTimers();
-
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(next.mock.calls[1][0]).not.toEqual(next.mock.calls[0][0]);
-    });
-  });
-
   describe('modifyCurrentQuestion', () => {
     it('should throw if quizee is not loaded', async () => {
       service.modifyCurrentQuestion({}).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
 
     it('should concat current question with the provided changes', async () => {
@@ -411,20 +568,20 @@ describe('QuizeeEditingService', () => {
         },
       };
 
-      service.create();
+      service.createQuizee();
       service.createQuestion().subscribe({ next, error });
       service.modifyCurrentQuestion(change1 as any as QuestionPair);
       service.modifyCurrentQuestion(change2 as any as QuestionPair);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(3);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
       expect(next.mock.calls[1][0]).toEqual(_.merge({}, next.mock.calls[0][0], change1));
       expect(next.mock.calls[2][0]).toEqual(_.merge({}, next.mock.calls[1][0], change2));
     });
 
-    it('should push new quizee', async () => {
+    it('should push quizee', async () => {
       const change1 = {
         question: {
           change1: 'change1',
@@ -437,251 +594,1201 @@ describe('QuizeeEditingService', () => {
         },
       };
 
-      service.create().subscribe({ next, error });
+      service.createQuizee().subscribe({ next, error });
       service.createQuestion();
       service.modifyCurrentQuestion(change1 as any as QuestionPair);
       service.modifyCurrentQuestion(change2 as any as QuestionPair);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(4);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(4);
       expect(next.mock.calls[1][0]).not.toEqual(next.mock.calls[0][0]);
       expect(next.mock.calls[2][0]).not.toEqual(next.mock.calls[1][0]);
     });
-  });
 
-  describe('setAnswer', () => {
-    it('should throw if quizee is not loaded', async () => {
-      service.setAnswer([]).subscribe({ next, error });
+    it('should not push quizee if it is the same', async () => {
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      service.createQuizee().subscribe({ next, error });
+      service.createQuestion();
+      service.modifyCurrentQuestion(change1 as any as QuestionPair);
+      service.modifyCurrentQuestion(change1 as any as QuestionPair);
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+    });
+
+    it('should push modified question', async () => {
+      let next1 = jest.fn();
+      let error1 = jest.fn();
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      const change2 = {
+        answer: {
+          change2: 'change2',
+        },
+      };
+
+      service.createQuizee();
+      service.createQuestion().subscribe({ next, error });
+      service.createQuestion().subscribe({ next: next1, error: error1 });
+      service.selectQuestion(1);
+      service.modifyCurrentQuestion(change1 as any as QuestionPair);
+      service.modifyCurrentQuestion(change2 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[1][0]).not.toEqual(next.mock.calls[0][0]);
+      expect(next.mock.calls[2][0]).not.toEqual(next.mock.calls[1][0]);
+
+      expect(next1).toBeCalledTimes(1);
+      expect(error1).not.toBeCalled();
+    });
+
+    it('should not push modified question if it is the same', async () => {
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      service.createQuizee();
+      service.createQuestion().subscribe({ next, error });
+      service.modifyCurrentQuestion(change1 as any as QuestionPair);
+      service.modifyCurrentQuestion(change1 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+    });
+  });
+
+  describe('modifyQuestion', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.modifyQuestion(0, {}).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should throw if index is invalid', async () => {
+      service.createQuizee();
+      service.modifyQuestion(-1, {}).subscribe({ next, error });
+      service.modifyQuestion(1, {}).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should concat specified question with the provided changes', async () => {
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      const change2 = {
+        answer: {
+          change2: 'change2',
+        },
+      };
+
+      service.createQuizee();
+      const sub = service.createQuestion().subscribe({ next, error });
+      service.modifyQuestion(1, change1 as any as QuestionPair);
+      service.modifyQuestion(1, change2 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[1][0]).toEqual(_.merge({}, next.mock.calls[0][0], change1));
+      expect(next.mock.calls[2][0]).toEqual(_.merge({}, next.mock.calls[1][0], change2));
+
+      sub.unsubscribe();
+      next.mockReset();
+      error.mockReset();
+
+      service.getQuestion(0).subscribe({ next, error });
+      service.modifyQuestion(0, change1 as any as QuestionPair);
+      service.modifyQuestion(0, change2 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[1][0]).toEqual(_.merge({}, next.mock.calls[0][0], change1));
+      expect(next.mock.calls[2][0]).toEqual(_.merge({}, next.mock.calls[1][0], change2));
+    });
+
+    it('should push quizee', async () => {
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      const change2 = {
+        answer: {
+          change2: 'change2',
+        },
+      };
+
+      service.createQuizee().subscribe({ next, error });
+      service.createQuestion();
+      service.modifyQuestion(0, change1 as any as QuestionPair);
+      service.modifyQuestion(0, change2 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(4);
+      expect(next.mock.calls[2][0]).not.toEqual(next.mock.calls[1][0]);
+      expect(next.mock.calls[3][0]).not.toEqual(next.mock.calls[2][0]);
+    });
+
+    it('should not push quizee if it is the same', async () => {
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      service.createQuizee().subscribe({ next, error });
+      service.createQuestion();
+      service.modifyQuestion(0, change1 as any as QuestionPair);
+      service.modifyQuestion(0, change1 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+    });
+
+    it('should push modified question', async () => {
+      let next1 = jest.fn();
+      let error1 = jest.fn();
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      const change2 = {
+        answer: {
+          change2: 'change2',
+        },
+      };
+
+      service.createQuizee();
+      service.createQuestion().subscribe({ next, error });
+      service.createQuestion().subscribe({ next: next1, error: error1 });
+      service.modifyQuestion(1, change1 as any as QuestionPair);
+      service.modifyQuestion(1, change2 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[1][0]).not.toEqual(next.mock.calls[0][0]);
+      expect(next.mock.calls[2][0]).not.toEqual(next.mock.calls[1][0]);
+
+      expect(next1).toBeCalledTimes(1);
+      expect(error1).not.toBeCalled();
+    });
+
+    it('should not push modified question if it is the same', async () => {
+      const change1 = {
+        question: {
+          change1: 'change1',
+        },
+      };
+
+      service.createQuizee();
+      service.createQuestion().subscribe({ next, error });
+      service.modifyQuestion(1, change1 as any as QuestionPair);
+      service.modifyQuestion(1, change1 as any as QuestionPair);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+    });
+  });
+
+  describe('selectQuestion', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.selectQuestion(0).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should throw if index is out of range', async () => {
+      service.createQuizee();
+      service.selectQuestion(1).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should throw if index is invalid', async () => {
+      service.createQuizee();
+      service.selectQuestion(-1).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should push current question', async () => {
+      service.createQuizee();
+      service.createQuestion();
+      service.createQuestion();
+      service.selectQuestion(0).subscribe({ next, error });
+      service.selectQuestion(1);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[1][0]).not.toEqual(next.mock.calls[0][0]);
+    });
+  });
+
+  describe('getCurrentQuestion', () => {
+    it('should not emit if quizee is not loaded', async () => {
+      let complete = jest.fn();
+      service.getCurrentQuestion().subscribe({ next, error, complete });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should emit on quizee create', async () => {
+      let complete = jest.fn();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error, complete });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should emit on question create', async () => {
+      let complete = jest.fn();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error, complete });
+      service.createQuestion();
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should emit on question index change', async () => {
+      let complete = jest.fn();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error, complete });
+      service.createQuestion();
+      service.selectQuestion(0);
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[0][0].question.id).toEqual(next.mock.calls[2][0].question.id);
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should not emit if data is the same', async () => {
+      let complete = jest.fn();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error, complete });
+      service.setCurrentQuestionType('ONE_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+  });
+
+  describe('getQuestion', () => {
+    it('should not emit if quizee is not loaded', async () => {
+      let complete = jest.fn();
+      service.getQuestion(0).subscribe({ next, error, complete });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should throw if index is invalid', async () => {
+      let complete = jest.fn();
+
+      service.createQuizee();
+      service.getQuestion(-1).subscribe({ next, error, complete });
+      service.getQuestion(1).subscribe({ next, error, complete });
+      service.createQuestion();
+      service.getQuestion(1).subscribe({ next, error, complete });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).toBeCalledTimes(2);
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should not emit on question create', async () => {
+      let complete = jest.fn();
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error, complete });
+      service.createQuestion();
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should not emit on question index change', async () => {
+      let complete = jest.fn();
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error, complete });
+      service.createQuestion();
+      service.selectQuestion(0);
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+
+    it('should not emit if data is the same', async () => {
+      let complete = jest.fn();
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error, complete });
+      service.setQuestionType(0, 'ONE_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+      expect(complete).not.toBeCalled();
+    });
+  });
+
+  describe('setCurrentQuestionAnswerConfig', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.setCurrentQuestionAnswerConfig({}).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should push quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionAnswerConfig({ equalCase: true });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should not push quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionAnswerConfig({});
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should push current question', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswerConfig({ equalCase: true });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should not push current question if it is the same', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswerConfig({});
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should apply changes', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswerConfig({ equalCase: true });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[1][0].answer.config).toEqual({ ...next.mock.calls[0][0].answer.config, equalCase: true });
+      expect(error).not.toBeCalled();
+    });
+
+    it('should make deep copy', async () => {
+      const object = { someArray: [{ a: 1 }] } as any;
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswerConfig(object);
+      object.someArray[0].a = 2;
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[1][0].answer.config.someArray).toEqual([{ a: 1 }]);
+      expect(error).not.toBeCalled();
+    });
+  });
+
+  describe('setAnswerConfig', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.setAnswerConfig(0, {}).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should push quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setAnswerConfig(0, { equalCase: true });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should not push quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setAnswerConfig(0, {});
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should push changed question', async () => {
+      service.createQuizee();
+      service.createQuestion();
+      service.getQuestion(0).subscribe({ next, error });
+      service.setAnswerConfig(0, { equalCase: true });
+      service.getQuestion(1).subscribe({ next, error });
+      service.setAnswerConfig(1, { equalCase: true });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(4);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should not push question if it is the same', async () => {
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.setAnswerConfig(0, {});
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should apply changes', async () => {
+      service.createQuizee();
+      service.createQuestion();
+      service.createQuestion();
+      service.getQuestion(1).subscribe({ next, error });
+      service.setAnswerConfig(1, { equalCase: true });
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[1][0].answer.config).toEqual({ ...next.mock.calls[0][0].answer.config, equalCase: true });
+      expect(error).not.toBeCalled();
+    });
+
+    it('should make deep copy', async () => {
+      const object = { someArray: [{ a: 1 }] } as any;
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.setAnswerConfig(0, object);
+      object.someArray[0].a = 2;
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[1][0].answer.config.someArray).toEqual([{ a: 1 }]);
+      expect(error).not.toBeCalled();
+    });
+  });
+
+  describe('setCurrentQuestionType', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.setCurrentQuestionType('ONE_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should push quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionType('SEVERAL_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should not push quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionType('ONE_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should push current question', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionType('SEVERAL_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should not push current question if it is the same', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionType('ONE_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should change question type', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionType('SEVERAL_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[1][0].question.type).toBe('SEVERAL_TRUE');
+      expect(next.mock.calls[1][0].question.type).not.toBe(next.mock.calls[0][0].question.type);
+    });
+
+    it('should clear answer options and set answer on switch to WRITE_ANSWER', async () => {
+      service.createQuizee();
+      service.setCurrentQuestionAnswerOptions([{ id: 'abc', value: 'abc' }]);
+      service.setCurrentQuestionAnswer(['abc']);
+
+      service.setCurrentQuestionType('WRITE_ANSWER').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[0][0].answer.answer.length).toBe(1);
+      expect(next.mock.calls[0][0].answer.answer[0]).not.toBe('');
+      expect(next.mock.calls[0][0].question.answerOptions.length).toBe(0);
+    });
+
+    it('should leave question valid after switching in both ways', async () => {
+      const { verifyQuestion, verifyAnswer } = jest.requireActual('@di-strix/quizee-verification-functions');
+
+      service.createQuizee();
+      service.createQuestion();
+      service.setCurrentQuestionType('WRITE_ANSWER').subscribe({ next, error });
+
+      expect(await verifyQuestion(next.mock.calls[0][0].question)).toEqual([]);
+      expect(await verifyAnswer(next.mock.calls[0][0].answer)).toEqual([]);
+
+      service.setCurrentQuestionType('ONE_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(await verifyQuestion(next.mock.calls[1][0].question)).toEqual([]);
+      expect(await verifyAnswer(next.mock.calls[1][0].answer)).toEqual([]);
+
+      service.setCurrentQuestionType('SEVERAL_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(await verifyQuestion(next.mock.calls[2][0].question)).toEqual([]);
+      expect(await verifyAnswer(next.mock.calls[2][0].answer)).toEqual([]);
+    });
+
+    it('should add answer and answer option when switching from WRITE_ANSWER', async () => {
+      service.createQuizee();
+      service.setCurrentQuestionType('WRITE_ANSWER');
+      service.setCurrentQuestionType('ONE_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[0][0].answer.answer.length).toBe(1);
+      expect(next.mock.calls[0][0].question.answerOptions.length).toBe(1);
+      expect(next.mock.calls[0][0].answer.answer[0]).toBe(next.mock.calls[0][0].question.answerOptions[0].id);
+    });
+  });
+
+  describe('setQuestionType', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.setQuestionType(0, 'ONE_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should throw if index is invalid', async () => {
+      service.createQuizee();
+      service.setQuestionType(-1, 'SEVERAL_TRUE').subscribe({ next, error });
+      service.setQuestionType(1, 'SEVERAL_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should push quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setQuestionType(0, 'SEVERAL_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should not push quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setQuestionType(0, 'ONE_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should push modified question', async () => {
+      let next1 = jest.fn();
+      let error1 = jest.fn();
+
+      service.createQuizee();
+      service.createQuestion().subscribe({ next, error });
+      service.createQuestion().subscribe({ next: next1, error: error1 });
+      service.createQuestion();
+      service.setQuestionType(1, 'SEVERAL_TRUE');
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+
+      expect(next1).toBeCalledTimes(1);
+      expect(error1).not.toBeCalled();
+    });
+
+    it('should not push question if it is the same', async () => {
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.setQuestionType(0, 'ONE_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should change question type', async () => {
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.setQuestionType(0, 'SEVERAL_TRUE');
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[1][0].question.type).toBe('SEVERAL_TRUE');
+      expect(next.mock.calls[1][0].question.type).not.toBe(next.mock.calls[0][0].question.type);
+    });
+
+    it('should clear answer options and set answer on switch to WRITE_ANSWER', async () => {
+      service.createQuizee();
+      service.setAnswerOptions(0, [{ id: 'abc', value: 'abc' }]);
+      service.setAnswer(0, ['abc']);
+
+      service.setQuestionType(0, 'WRITE_ANSWER').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[0][0].answer.answer.length).toBe(1);
+      expect(next.mock.calls[0][0].answer.answer[0]).not.toBe('');
+      expect(next.mock.calls[0][0].question.answerOptions.length).toBe(0);
+    });
+
+    it('should leave question valid after switching in both ways', async () => {
+      const { verifyQuestion, verifyAnswer } = jest.requireActual('@di-strix/quizee-verification-functions');
+
+      service.createQuizee();
+      service.createQuestion();
+      service.setQuestionType(1, 'WRITE_ANSWER').subscribe({ next, error });
+
+      expect(await verifyQuestion(next.mock.calls[0][0].question)).toEqual([]);
+      expect(await verifyAnswer(next.mock.calls[0][0].answer)).toEqual([]);
+
+      service.setQuestionType(1, 'ONE_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(await verifyQuestion(next.mock.calls[1][0].question)).toEqual([]);
+      expect(await verifyAnswer(next.mock.calls[1][0].answer)).toEqual([]);
+
+      service.setQuestionType(1, 'SEVERAL_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(await verifyQuestion(next.mock.calls[2][0].question)).toEqual([]);
+      expect(await verifyAnswer(next.mock.calls[2][0].answer)).toEqual([]);
+    });
+
+    it('should add answer and answer option when switching from WRITE_ANSWER', async () => {
+      service.createQuizee();
+      service.setQuestionType(0, 'WRITE_ANSWER');
+      service.setQuestionType(0, 'ONE_TRUE').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[0][0].answer.answer.length).toBe(1);
+      expect(next.mock.calls[0][0].question.answerOptions.length).toBe(1);
+      expect(next.mock.calls[0][0].answer.answer[0]).toBe(next.mock.calls[0][0].question.answerOptions[0].id);
+    });
+  });
+
+  describe('setCurrentQuestionAnswer', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.setCurrentQuestionAnswer([]).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
 
     it('should set answer for current question', async () => {
       const answer: AnswerOptionId[] = ['1', '2', '3'];
 
-      service.create();
+      service.createQuizee();
       service.createQuestion();
-      service.setAnswer(answer).subscribe({ next, error });
+      service.setCurrentQuestionAnswer(answer).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(1);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(1);
       expect(next.mock.calls[0][0].answer.answer).toEqual(answer);
     });
 
     it('should push new quizee', async () => {
-      service.create().subscribe({ next, error });
-      service.createQuestion();
-      service.setAnswer(['1']);
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionAnswer(['1']);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(3);
-      expect(next.mock.calls[0][0]).not.toEqual(next.mock.calls[2][0]);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[0][0]).not.toEqual(next.mock.calls[1][0]);
+    });
+
+    it('should not push new quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionAnswer(['1']);
+      service.setCurrentQuestionAnswer(['1']);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+    });
+
+    it('should push current question', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswer(['1']);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+    });
+
+    it('should not push current question if it is the same', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswer(['1']);
+      service.setCurrentQuestionAnswer(['1']);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
     });
   });
 
-  describe('setAnswerOptions', () => {
+  describe('setAnswer', () => {
     it('should throw if quizee is not loaded', async () => {
-      service.setAnswerOptions([]).subscribe({ next, error });
+      service.setAnswer(0, []).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should throw if index is invalid', async () => {
+      service.createQuizee();
+      service.setAnswer(-1, []).subscribe({ next, error });
+      service.setAnswer(1, []).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalledTimes(2);
+    });
+
+    it('should set answer for specified question', async () => {
+      const answer: AnswerOptionId[] = ['1', '2', '3'];
+
+      service.createQuizee();
+      service.createQuestion();
+      service.getQuizee().subscribe({ next, error });
+      service.setAnswer(0, answer);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[1][0].answers[0].answer).toEqual(answer);
+      expect(next.mock.calls[0][0].answers[0].answer).toEqual(next.mock.calls[0][0].answers[0].answer);
+    });
+
+    it('should push new quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setAnswer(0, ['1']);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[0][0]).not.toEqual(next.mock.calls[1][0]);
+    });
+
+    it('should not push new quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setAnswer(0, ['1']);
+      service.setAnswer(0, ['1']);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+    });
+
+    it('should push specified question', async () => {
+      let next1 = jest.fn();
+      let error1 = jest.fn();
+
+      service.createQuizee();
+      service.createQuestion();
+      service.getQuestion(0).subscribe({ next: next1, error: error1 });
+      service.getQuestion(1).subscribe({ next, error });
+      service.setAnswer(1, ['1']);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+
+      expect(next1).toBeCalledTimes(1);
+      expect(error1).not.toBeCalled();
+    });
+
+    it('should not push question if it is the same', async () => {
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.setAnswer(0, ['1']);
+      service.setAnswer(0, ['1']);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+    });
+  });
+
+  describe('setCurrentQuestionAnswerOptions', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.setCurrentQuestionAnswerOptions([]).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
 
     it('should set answer options for current question', async () => {
       const answerOptions: AnswerOption[] = [{ id: '1', value: '' }];
 
-      service.create();
+      service.createQuizee().subscribe({ next, error });
       service.createQuestion();
-      service.setAnswerOptions(answerOptions).subscribe({ next, error });
+      service.setCurrentQuestionAnswerOptions(answerOptions);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(1);
-      expect(next.mock.calls[0][0].question.answerOptions).toEqual(answerOptions);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[2][0].questions[1].answerOptions).toEqual(answerOptions);
+      expect(next.mock.calls[2][0].questions[0].answerOptions).toEqual(
+        next.mock.calls[0][0].questions[0].answerOptions
+      );
     });
 
     it('should push new quizee', async () => {
-      service.create().subscribe({ next, error });
-      service.createQuestion();
-      service.setAnswerOptions([{ id: '1', value: '' }]);
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionAnswerOptions([{ id: '1', value: '' }]);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(3);
-      expect(next.mock.calls[1][0]).not.toEqual(next.mock.calls[2][0]);
-    });
-  });
-
-  describe('_pushQuizee', () => {
-    it('should not push if quizee is falsy', async () => {
-      const testingService = service as any as { quizee: Quiz; get: () => Observable<Quiz>; _pushQuizee: () => void };
-
-      testingService.get().subscribe({ next, error });
-      testingService._pushQuizee();
-
-      await jest.runAllTimers();
-
-      expect(testingService.quizee).toBeFalsy();
-      expect(next).not.toHaveBeenCalled();
-      expect(error).not.toHaveBeenCalled();
-    });
-
-    it('should push quizee if it exists', async () => {
-      const testingService = service as any as {
-        quizee: Quiz;
-        get: () => Observable<Quiz>;
-        _pushQuizee: () => void;
-        create: () => Observable<Quiz>;
-      };
-
-      testingService.create().subscribe({ next, error });
-      testingService._pushQuizee();
-
-      await jest.runAllTimers();
-
-      expect(testingService.quizee).toBeTruthy();
+      expect(error).not.toBeCalled();
       expect(next).toBeCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
+      expect(next.mock.calls[0][0]).not.toEqual(next.mock.calls[1][0]);
     });
 
-    it('should make deep copy', async () => {
-      const testingService = service as any as {
-        quizee: Quiz;
-        create: () => Observable<Quiz>;
-        get: () => Observable<Quiz>;
-        _pushQuizee: () => void;
-      };
-
-      testingService.create().subscribe({ next, error });
-      testingService._pushQuizee();
-      testingService.quizee.info.caption = '123123';
+    it('should not push new quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setCurrentQuestionAnswerOptions([{ id: '1', value: '' }]);
+      service.setCurrentQuestionAnswerOptions([{ id: '1', value: '' }]);
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
-      expect(next.mock.calls[1][0].info.caption).not.toEqual('123123');
-      expect(next.mock.calls[1][0].info.caption).toEqual(next.mock.calls[0][0].info.caption);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
     });
-  });
 
-  describe('_pushCurrentQuestion', () => {
-    it('should not push if quizee is not created', async () => {
-      const testingService = service as any as {
-        get: () => Observable<Quiz>;
-        _pushCurrentQuestion: () => void;
-      };
-
-      testingService.get().subscribe({ next, error });
-      testingService._pushCurrentQuestion();
+    it('should push current question', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswerOptions([{ id: '1', value: '' }]);
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).not.toHaveBeenCalled();
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
     });
 
-    it('should not push if question is not selected', async () => {
-      const testingService = service as any as {
-        create: () => Observable<Quiz>;
-        getCurrentQuestion: () => Observable<QuestionPair>;
-        _pushCurrentQuestion: () => void;
-      };
-
-      testingService.getCurrentQuestion().subscribe({ next, error });
-      testingService._pushCurrentQuestion();
+    it('should not push current question if it the same', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.setCurrentQuestionAnswerOptions([{ id: '1', value: '' }]);
+      service.setCurrentQuestionAnswerOptions([{ id: '1', value: '' }]);
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).not.toHaveBeenCalled();
-    });
-
-    it('should push', async () => {
-      const testingService = service as any as {
-        quizee: Quiz;
-        create: () => Observable<Quiz>;
-        createQuestion: () => Observable<QuestionPair>;
-        getCurrentQuestion: () => Observable<QuestionPair>;
-        _pushCurrentQuestion: () => void;
-      };
-
-      testingService.create();
-      testingService.createQuestion().subscribe({ next, error });
-      testingService._pushCurrentQuestion();
-
-      await jest.runAllTimers();
-
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
-    });
-
-    it('should make deep copy', async () => {
-      const testingService = service as any as {
-        quizee: Quiz;
-        create: () => Observable<Quiz>;
-        createQuestion: () => Observable<QuestionPair>;
-        getCurrentQuestion: () => Observable<QuestionPair>;
-        _pushCurrentQuestion: () => void;
-      };
-
-      testingService.create();
-      testingService.createQuestion().subscribe({ next, error });
-      testingService._pushCurrentQuestion();
-      testingService.quizee.answers[0].answerTo = '123123';
-
-      await jest.runAllTimers();
-
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
-      expect(next.mock.calls[1][0].answer.answerTo).not.toEqual('123123');
-      expect(next.mock.calls[1][0].answer.answerTo).toEqual(next.mock.calls[0][0].answer.answerTo);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
     });
   });
 
-  describe('addAnswerOption', () => {
-    it('should throw if quizee is not created', async () => {
-      service.addAnswerOption().subscribe({ next, error });
+  describe('setAnswerOptions', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.setAnswerOptions(0, []).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
 
-    it('should create new answer option for selected question', async () => {
-      service.create();
-      service.createQuestion().subscribe({ next, error });
-      service.addAnswerOption();
+    it('should throw if index is invalid', async () => {
+      service.createQuizee();
+      service.setAnswerOptions(-1, []).subscribe({ next, error });
+      service.setAnswerOptions(1, []).subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(next.mock.calls[0][0].question.answerOptions.length).toBe(1);
-      expect(next.mock.calls[1][0].question.answerOptions.length).toBe(2);
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalledTimes(2);
+    });
+
+    it('should set answer options for specified question', async () => {
+      const answerOptions: AnswerOption[] = [{ id: '1', value: '' }];
+
+      service.createQuizee().subscribe({ next, error });
+      service.createQuestion();
+      service.setAnswerOptions(0, answerOptions);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[2][0].questions[0].answerOptions).toEqual(answerOptions);
+      expect(next.mock.calls[2][0].questions[1].answerOptions).toEqual(
+        next.mock.calls[1][0].questions[1].answerOptions
+      );
+    });
+
+    it('should push new quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setAnswerOptions(0, [{ id: '1', value: '' }]);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[0][0]).not.toEqual(next.mock.calls[1][0]);
+    });
+
+    it('should not push new quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.setAnswerOptions(0, [{ id: '1', value: '' }]);
+      service.setAnswerOptions(0, [{ id: '1', value: '' }]);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[0][0]).not.toEqual(next.mock.calls[1][0]);
+    });
+
+    it('should push specified question', async () => {
+      let next1 = jest.fn();
+      let error1 = jest.fn();
+
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.createQuestion();
+      service.getQuestion(1).subscribe({ next: next1, error: error1 });
+      service.setAnswerOptions(0, [{ id: '1', value: '' }]);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+
+      expect(error1).not.toBeCalled();
+      expect(next1).toBeCalledTimes(1);
+    });
+
+    it('should not push specified question if it is the same', async () => {
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.setAnswerOptions(0, [{ id: '1', value: '' }]);
+      service.setAnswerOptions(0, [{ id: '1', value: '' }]);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(2);
+    });
+  });
+
+  describe('addAnswerOptionForCurrentQuestion', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.addAnswerOptionForCurrentQuestion().subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should create new answer option for current question', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.createQuestion();
+      service.addAnswerOptionForCurrentQuestion();
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[1][0].questions[1].answerOptions.length).toBe(1);
+      expect(next.mock.calls[2][0].questions[1].answerOptions.length).toBe(2);
+      expect(next.mock.calls[2][0].questions[0].answerOptions.length).toBe(1);
     });
 
     it('should create unique id for each answer option', async () => {
-      service.create();
-      service.createQuestion().subscribe({ next, error });
-      service.addAnswerOption();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.addAnswerOptionForCurrentQuestion();
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
+      expect(next).toBeCalledTimes(2);
       expect(next.mock.calls[1][0].question.answerOptions[0].id).not.toBe(
         next.mock.calls[1][0].question.answerOptions[1].id
       );
@@ -690,34 +1797,134 @@ describe('QuizeeEditingService', () => {
     it('should create valid answer option', async () => {
       const { verifyAnswerOption } = jest.requireActual('@di-strix/quizee-verification-functions');
 
-      service.create();
-      service.createQuestion().subscribe({ next, error });
-      service.addAnswerOption();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.addAnswerOptionForCurrentQuestion();
 
       await jest.runAllTimers();
 
       expect(await verifyAnswerOption(next.mock.calls[1][0].question.answerOptions[1])).toEqual([]);
     });
-  });
 
-  describe('removeAnswerOption', () => {
-    it('should throw if quizee is not created', async () => {
-      service.removeAnswerOption('').subscribe({ next, error });
+    it('should push quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.addAnswerOptionForCurrentQuestion();
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should push current question', async () => {
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.addAnswerOptionForCurrentQuestion();
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+  });
+
+  describe('addAnswerOption', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.addAnswerOption(0).subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should create new answer option for specified question', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.createQuestion();
+      service.addAnswerOption(0);
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
+      expect(next.mock.calls[1][0].questions[0].answerOptions.length).toBe(1);
+      expect(next.mock.calls[2][0].questions[0].answerOptions.length).toBe(2);
+      expect(next.mock.calls[2][0].questions[1].answerOptions.length).toBe(1);
+    });
+
+    it('should create unique id for each answer option', async () => {
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.addAnswerOption(0);
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(next.mock.calls[1][0].question.answerOptions[0].id).not.toBe(
+        next.mock.calls[1][0].question.answerOptions[1].id
+      );
+    });
+
+    it('should create valid answer option', async () => {
+      const { verifyAnswerOption } = jest.requireActual('@di-strix/quizee-verification-functions');
+
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+      service.addAnswerOption(0);
+
+      await jest.runAllTimers();
+
+      expect(await verifyAnswerOption(next.mock.calls[1][0].question.answerOptions[1])).toEqual([]);
+    });
+
+    it('should push quizee', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.addAnswerOption(0);
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+    });
+
+    it('should push specified question', async () => {
+      let next1 = jest.fn();
+      let error1 = jest.fn();
+
+      service.createQuizee();
+      service.createQuestion();
+      service.getQuestion(0).subscribe({ next, error });
+      service.getQuestion(1).subscribe({ next: next1, error: error1 });
+      service.addAnswerOption(0);
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(2);
+      expect(error).not.toBeCalled();
+
+      expect(next1).toBeCalledTimes(1);
+      expect(error1).not.toBeCalled();
+    });
+  });
+
+  describe('removeAnswerOptionForCurrentQuestion', () => {
+    it('should throw if quizee is not loaded', async () => {
+      service.removeAnswerOptionForCurrentQuestion('').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
     });
 
     it('should remove answer option with provided id for selected question', async () => {
-      service.create();
-      service.createQuestion().subscribe({ next, error });
-      service.addAnswerOption();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.addAnswerOptionForCurrentQuestion();
 
       await jest.runAllTimers();
 
-      service.removeAnswerOption(next.mock.calls[1][0].question.answerOptions[0].id);
+      service.removeAnswerOptionForCurrentQuestion(next.mock.calls[1][0].question.answerOptions[0].id);
 
       await jest.runAllTimers();
 
@@ -728,212 +1935,181 @@ describe('QuizeeEditingService', () => {
     });
 
     it('should remove answer with provided id for selected question', async () => {
-      service.create();
-      service.createQuestion().subscribe({ next, error });
-      service.addAnswerOption();
+      service.createQuizee();
+      service.getCurrentQuestion().subscribe({ next, error });
+      service.addAnswerOptionForCurrentQuestion();
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
-      service.setAnswer([next.mock.calls[1][0].question.answerOptions[0].id]);
-      service.removeAnswerOption(next.mock.calls[1][0].question.answerOptions[0].id);
+      expect(next).toBeCalledTimes(2);
+      service.setCurrentQuestionAnswerOptions([next.mock.calls[1][0].question.answerOptions[0].id]);
+      service.removeAnswerOptionForCurrentQuestion(next.mock.calls[1][0].question.answerOptions[0].id);
 
       await jest.runAllTimers();
 
-      expect(error).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(4);
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(4);
       expect(next.mock.calls[3][0].answer.answer).toEqual([]);
     });
-  });
 
-  describe('_getCurrentQuestion', () => {
-    it('should throw if quizee is not loaded', async () => {
-      await expect((async () => (service as any)._getCurrentQuestion())()).rejects.toThrowError();
-    });
-
-    it('should return current question', async () => {
-      service.create();
-
-      const qp: QuestionPair = (service as any)._getCurrentQuestion();
-      const quizee: Quiz = (service as any).quizee;
-
-      expect(qp.question).toEqual(quizee.questions[service.getCurrentQuestionIndex()]);
-      expect(qp.answer).toEqual(quizee.answers[service.getCurrentQuestionIndex()]);
-    });
-  });
-
-  describe('setAnswerConfig', () => {
-    it('should throw if quizee is not loaded', async () => {
-      service.setAnswerConfig({}).subscribe({ next, error });
+    it('should do nothing if id not found', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.removeAnswerOptionForCurrentQuestion('');
+      service.removeAnswerOptionForCurrentQuestion('123123');
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
     });
 
     it('should push quizee', async () => {
-      service.create().subscribe({ next, error });
-      service.setAnswerConfig({});
+      service.createQuizee().subscribe({ next, error });
+      service.removeAnswerOptionForCurrentQuestion(service.quizee?.questions[0].answerOptions[0].id || '');
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
     });
 
-    it('should push current question', async () => {
-      service.create();
-      service.getCurrentQuestion().subscribe({ next, error });
-      service.setAnswerConfig({});
+    it('should not push quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+
+      const id = service.quizee?.questions[0].answerOptions[0]?.id || '';
+      service.removeAnswerOptionForCurrentQuestion(id);
+      service.removeAnswerOptionForCurrentQuestion(id);
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
-    });
-
-    it('should apply changes', async () => {
-      service.create();
-      service.getCurrentQuestion().subscribe({ next, error });
-      service.setAnswerConfig({ equalCase: true });
-
-      await jest.runAllTimers();
-
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(next.mock.calls[1][0].answer.config).toEqual({ ...next.mock.calls[0][0].answer.config, equalCase: true });
-      expect(error).not.toHaveBeenCalled();
-    });
-
-    it('should make deep copy', async () => {
-      const object = { someArray: [{ a: 1 }] } as any;
-      service.create();
-      service.getCurrentQuestion().subscribe({ next, error });
-      service.setAnswerConfig(object);
-      object.someArray[0].a = 2;
-
-      await jest.runAllTimers();
-
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(next.mock.calls[1][0].answer.config.someArray).toEqual([{ a: 1 }]);
-      expect(error).not.toHaveBeenCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
     });
   });
 
-  describe('setQuestionType', () => {
+  describe('removeAnswerOption', () => {
     it('should throw if quizee is not loaded', async () => {
-      service.setQuestionType('ONE_TRUE').subscribe({ next, error });
+      service.removeAnswerOption(0, '').subscribe({ next, error });
 
       await jest.runAllTimers();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(error).toHaveBeenCalled();
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalled();
+    });
+
+    it('should throw if index is invalid', async () => {
+      service.createQuizee();
+      service.removeAnswerOption(-1, '').subscribe({ next, error });
+      service.removeAnswerOption(1, '').subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      expect(next).not.toBeCalled();
+      expect(error).toBeCalledTimes(2);
+    });
+
+    it('should remove answer option with provided id for specified question', async () => {
+      service.createQuizee();
+      service.createQuestion();
+      service.addAnswerOption(0);
+      service.getQuizee().subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      service.removeAnswerOption(0, next.mock.calls[0][0].questions[0].answerOptions[0].id);
+
+      await jest.runAllTimers();
+
+      expect(next.mock.calls[0][0].questions[0].answerOptions.length).toBe(2);
+      expect(next.mock.calls[1][0].questions[0].answerOptions[0].id).not.toBe(
+        next.mock.calls[0][0].questions[0].answerOptions[0].id
+      );
+      expect(next.mock.calls[0][0].questions[1].answerOptions[0].id).toBe(
+        next.mock.calls[1][0].questions[1].answerOptions[0].id
+      );
+    });
+
+    it('should remove answer with provided id for specified question', async () => {
+      service.createQuizee();
+      service.createQuestion();
+      service.getQuizee().subscribe({ next, error });
+
+      await jest.runAllTimers();
+
+      service.removeAnswerOption(0, next.mock.calls[0][0].questions[0].answerOptions[0].id);
+
+      await jest.runAllTimers();
+
+      expect(error).not.toBeCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(next.mock.calls[2][0].answers[0].answer).toEqual([]);
+      expect(next.mock.calls[2][0].answers[1].answer.length).toBe(1);
+    });
+
+    it('should do nothing if id not found', async () => {
+      service.createQuizee().subscribe({ next, error });
+      service.removeAnswerOption(0, '');
+      service.removeAnswerOption(0, '123123');
+
+      await jest.runAllTimers();
+
+      expect(next).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
     });
 
     it('should push quizee', async () => {
-      service.create().subscribe({ next, error });
-      service.setQuestionType('SEVERAL_TRUE');
+      service.createQuizee().subscribe({ next, error });
+      service.removeAnswerOption(0, next.mock.calls[0][0].questions[0].answerOptions[0].id);
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
     });
 
-    it('should push current question', async () => {
-      service.create();
-      service.getCurrentQuestion().subscribe({ next, error });
-      service.setQuestionType('SEVERAL_TRUE');
+    it('should not push quizee if it is the same', async () => {
+      service.createQuizee().subscribe({ next, error });
+
+      service.removeAnswerOption(0, next.mock.calls[0][0].questions[0].answerOptions[0].id);
+      service.removeAnswerOption(0, next.mock.calls[0][0].questions[0].answerOptions[0].id);
 
       await jest.runAllTimers();
 
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(error).not.toHaveBeenCalled();
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
     });
 
-    it('should change question type', async () => {
-      service.create();
-      service.getCurrentQuestion().subscribe({ next, error });
-      service.setQuestionType('SEVERAL_TRUE');
+    it('should push specified question', async () => {
+      let next1 = jest.fn();
+      let error1 = jest.fn();
 
-      await jest.runAllTimers();
-
-      expect(error).not.toHaveBeenCalled();
-      expect(next.mock.calls[1][0].question.type).toBe('SEVERAL_TRUE');
-      expect(next.mock.calls[1][0].question.type).not.toBe(next.mock.calls[0][0].question.type);
-    });
-
-    it('should clear answer options and set answer on switch to WRITE_ANSWER', async () => {
-      service.create();
-      service.setAnswerOptions([{ id: 'abc', value: 'abc' }]);
-      service.setAnswer(['abc']);
-
-      service.setQuestionType('WRITE_ANSWER').subscribe({ next, error });
-
-      await jest.runAllTimers();
-
-      expect(error).not.toHaveBeenCalled();
-      expect(next.mock.calls[0][0].answer.answer.length).toBe(1);
-      expect(next.mock.calls[0][0].answer.answer[0]).not.toBe('');
-      expect(next.mock.calls[0][0].question.answerOptions.length).toBe(0);
-    });
-
-    it('should leave question valid after switching in both ways', async () => {
-      const { verifyQuestion, verifyAnswer } = jest.requireActual('@di-strix/quizee-verification-functions');
-
-      service.create();
+      service.createQuizee();
       service.createQuestion();
-      service.setQuestionType('WRITE_ANSWER').subscribe({ next, error });
+      service.getQuestion(0).subscribe({ next, error });
+      service.getQuestion(1).subscribe({ next: next1, error: error1 });
 
-      expect(await verifyQuestion(next.mock.calls[0][0].question)).toEqual([]);
-      expect(await verifyAnswer(next.mock.calls[0][0].answer)).toEqual([]);
-
-      service.setQuestionType('ONE_TRUE').subscribe({ next, error });
+      service.removeAnswerOption(0, next.mock.calls[0][0].question.answerOptions[0].id);
 
       await jest.runAllTimers();
 
-      expect(await verifyQuestion(next.mock.calls[1][0].question)).toEqual([]);
-      expect(await verifyAnswer(next.mock.calls[1][0].answer)).toEqual([]);
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
 
-      service.setQuestionType('SEVERAL_TRUE').subscribe({ next, error });
+      expect(next1).toBeCalledTimes(1);
+      expect(error1).not.toBeCalled();
+    });
+
+    it('should not push specified question if it is the same', async () => {
+      service.createQuizee();
+      service.getQuestion(0).subscribe({ next, error });
+
+      service.removeAnswerOption(0, next.mock.calls[0][0].question.answerOptions[0].id);
+      service.removeAnswerOption(0, next.mock.calls[0][0].question.answerOptions[0].id);
 
       await jest.runAllTimers();
 
-      expect(await verifyQuestion(next.mock.calls[2][0].question)).toEqual([]);
-      expect(await verifyAnswer(next.mock.calls[2][0].answer)).toEqual([]);
-    });
-
-    it('should add answer and answer option when switching from WRITE_ANSWER', async () => {
-      service.create();
-      service.setQuestionType('WRITE_ANSWER');
-      service.setQuestionType('ONE_TRUE').subscribe({ next, error });
-
-      await jest.runAllTimers();
-
-      expect(error).not.toHaveBeenCalled();
-      expect(next.mock.calls[0][0].answer.answer.length).toBe(1);
-      expect(next.mock.calls[0][0].question.answerOptions.length).toBe(1);
-      expect(next.mock.calls[0][0].answer.answer[0]).toBe(next.mock.calls[0][0].question.answerOptions[0].id);
-    });
-  });
-
-  describe('getCurrentQuestionIndex', () => {
-    it('should return -1 if question is not created or loaded', () => {
-      expect(service.getCurrentQuestionIndex()).toEqual(-1);
-    });
-
-    it('should return proper index', () => {
-      service.create();
-
-      expect(service.getCurrentQuestionIndex()).toEqual(0);
-
-      service.createQuestion();
-
-      expect(service.getCurrentQuestionIndex()).toEqual(1);
-
-      service.selectQuestion(0);
-
-      expect(service.getCurrentQuestionIndex()).toEqual(0);
+      expect(next).toBeCalledTimes(3);
+      expect(error).not.toBeCalled();
     });
   });
 });

--- a/src/app/editor/settings/answer-input/answer-input.component.html
+++ b/src/app/editor/settings/answer-input/answer-input.component.html
@@ -1,8 +1,9 @@
 <app-setting-card>
   <app-setting-card-title
     title="Answer"
-    checkErrors="forCurrentQuestion"
+    checkErrors="forQuestion"
     path="answer"
+    [questionIndex]="questionIndex"
   ></app-setting-card-title>
   <app-setting-card-content>
     <div fxLayout="column">

--- a/src/app/editor/settings/answer-input/answer-input.component.spec.ts
+++ b/src/app/editor/settings/answer-input/answer-input.component.spec.ts
@@ -2,37 +2,203 @@ import * as _ from 'lodash';
 import { Subject, of } from 'rxjs';
 
 import { QuestionPair, QuizeeEditingService } from '../../quizee-editing.service';
+import { QuizeeValidators } from '../../quizee-validators';
 
 import { AnswerInputComponent } from './answer-input.component';
+
+jest.mock('../../quizee-validators');
 
 describe('AnswerInputComponent', () => {
   let component: AnswerInputComponent;
   let service: QuizeeEditingService;
+  let forQuestion: jest.Mock;
 
   beforeEach(() => {
+    forQuestion = jest.fn().mockReturnValue(() => of());
+    (QuizeeValidators.forQuestion as jest.Mock).mockImplementation((...args: any[]) => forQuestion(...args));
+
     service = new QuizeeEditingService();
     component = new AnswerInputComponent(service);
+
+    jest.useFakeTimers();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should subscribe to current question', () => {
-    const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-    getCurrentQuestion.mockReturnValue(of());
-    component.ngOnInit();
+  describe('onInit', () => {
+    it('should not subscribe', async () => {
+      jest.spyOn(service, 'getCurrentQuestion').mockReturnValue(of());
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      component.ngOnInit();
 
-    expect(service.getCurrentQuestion).toHaveBeenCalled();
+      await jest.runAllTimers();
+
+      expect(service.getCurrentQuestion).not.toBeCalled();
+      expect(service.getQuestion).not.toBeCalled();
+    });
+
+    it('should mark input as touched', async () => {
+      component.ngOnInit();
+
+      await jest.runAllTimers();
+
+      expect(component.answer.touched).toBeTruthy();
+    });
+  });
+
+  describe('onChanges', () => {
+    it('should subscribe on question with provided index', async () => {
+      const subject = new Subject();
+      jest.spyOn(service, 'getQuestion').mockReturnValue(subject as any);
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject.observed).toBeTruthy();
+    });
+
+    it('should unsubscribe from previous question', async () => {
+      const subject = new Subject();
+      const getQuestion = jest.spyOn(service, 'getQuestion').mockReturnValue(subject as any);
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      getQuestion.mockReset();
+      getQuestion.mockReturnValue(of());
+
+      component.questionIndex = 2;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject.observed).toBeFalsy();
+    });
+
+    it('should subscribe to new question with provided index', async () => {
+      const subject = new Subject();
+      const getQuestion = jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      getQuestion.mockReset();
+      getQuestion.mockReturnValue(subject as any);
+
+      component.questionIndex = 2;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject.observed).toBeTruthy();
+    });
+
+    it('should not subscribe if provided index is negative', async () => {
+      const subject1 = new Subject();
+      const subject2 = new Subject();
+      const getQuestion = jest.spyOn(service, 'getQuestion').mockReturnValue(subject1 as any);
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      getQuestion.mockReset();
+      getQuestion.mockReturnValue(subject2 as any);
+
+      component.questionIndex = -1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject1.observed).toBeFalsy();
+      expect(subject2.observed).toBeFalsy();
+    });
+
+    it('should clear async validators on question index change', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const clearAsyncValidators = jest.spyOn(component.answer, 'clearAsyncValidators');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      component.questionIndex = 0;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(clearAsyncValidators).toBeCalled();
+    });
+
+    it('should clear async validators if new question index is negative', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const clearAsyncValidators = jest.spyOn(component.answer, 'clearAsyncValidators');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      component.questionIndex = -1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(clearAsyncValidators).toBeCalled();
+    });
+
+    it('should set async validators with validators for new question', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const subject = new Subject();
+      const validatorFn = jest.fn().mockReturnValue(subject);
+      forQuestion.mockReturnValue(validatorFn);
+      const setAsyncValidators = jest.spyOn(component.answer, 'setAsyncValidators');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(forQuestion.mock.calls[0][1]).toEqual(1);
+      expect(setAsyncValidators).toBeCalledWith([validatorFn]);
+    });
+
+    it('should update validity after validators set', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const updateValueAndValidity = jest.spyOn(component.answer, 'updateValueAndValidity');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(updateValueAndValidity).toBeCalledWith({ emitEvent: false });
+    });
   });
 
   describe('answer', () => {
     describe('input value change', () => {
-      it('should update quizee on input value change', async () => {
-        jest.useFakeTimers();
-
-        const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-        getCurrentQuestion.mockReturnValue(
+      it('should update specified question on input value change', async () => {
+        const getQuestion = jest.spyOn(service, 'getQuestion');
+        getQuestion.mockReturnValue(
           of({
             answer: { answer: [], answerTo: 'question id', config: { equalCase: false } },
             question: {
@@ -41,18 +207,29 @@ describe('AnswerInputComponent', () => {
               id: 'question id',
               type: 'WRITE_ANSWER',
             },
+            index: 1,
           } as QuestionPair)
         );
 
         const setAnswer = jest.spyOn(service, 'setAnswer');
 
+        component.questionIndex = 1;
         component.ngOnInit();
+        component.ngOnChanges({});
+
+        await jest.runAllTimers();
+
+        component.questionIndex = 2;
+        component.ngOnChanges({});
+
+        await jest.runAllTimers();
+
         component.answer.setValue('Some correct answer');
 
         await jest.runAllTimers();
 
-        expect(setAnswer).toHaveBeenCalledTimes(1);
-        expect(setAnswer.mock.calls[0][0]).toEqual(['Some correct answer']);
+        expect(setAnswer).toBeCalledTimes(1);
+        expect(setAnswer).toBeCalledWith(2, ['Some correct answer']);
       });
     });
 
@@ -60,8 +237,6 @@ describe('AnswerInputComponent', () => {
       let mockQuestionPair: QuestionPair;
 
       beforeEach(() => {
-        jest.useFakeTimers();
-
         mockQuestionPair = {
           answer: { answer: [], answerTo: 'question id', config: { equalCase: false } },
           question: {
@@ -70,6 +245,7 @@ describe('AnswerInputComponent', () => {
             id: 'question id',
             type: 'WRITE_ANSWER',
           },
+          index: 0,
         };
       });
 
@@ -77,10 +253,12 @@ describe('AnswerInputComponent', () => {
         mockQuestionPair.answer.answer = ['some value'];
 
         const subject = new Subject();
-        const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-        getCurrentQuestion.mockReturnValue(subject as any);
+        const getQuestion = jest.spyOn(service, 'getQuestion');
+        getQuestion.mockReturnValue(subject as any);
 
+        component.questionIndex = 1;
         component.ngOnInit();
+        component.ngOnChanges({});
         subject.next(_.cloneDeep(mockQuestionPair));
 
         await jest.runAllTimers();
@@ -98,10 +276,11 @@ describe('AnswerInputComponent', () => {
         mockQuestionPair.answer.answer = ['val'];
 
         const subject = new Subject();
-        const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-        getCurrentQuestion.mockReturnValue(subject as any);
+        const getQuestion = jest.spyOn(service, 'getQuestion');
+        getQuestion.mockReturnValue(subject as any);
 
         component.ngOnInit();
+        component.ngOnChanges({});
         subject.next(_.cloneDeep(mockQuestionPair));
 
         await jest.runAllTimers();
@@ -109,18 +288,16 @@ describe('AnswerInputComponent', () => {
         const setValue = jest.spyOn(component.answer, 'setValue');
         subject.next(_.cloneDeep(mockQuestionPair));
 
-        expect(setValue).not.toHaveBeenCalled();
+        expect(setValue).not.toBeCalled();
       });
     });
   });
 
   describe('config', () => {
     describe('config change', () => {
-      it('should update quizee on config change', async () => {
-        jest.useFakeTimers();
-
-        const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-        getCurrentQuestion.mockReturnValue(
+      it('should update specified question on config change', async () => {
+        const getQuestion = jest.spyOn(service, 'getQuestion');
+        getQuestion.mockReturnValue(
           of({
             answer: { answer: [], answerTo: 'question id', config: { equalCase: false } },
             question: {
@@ -129,18 +306,29 @@ describe('AnswerInputComponent', () => {
               id: 'question id',
               type: 'WRITE_ANSWER',
             },
+            index: 0,
           } as QuestionPair)
         );
 
         const setAnswerConfig = jest.spyOn(service, 'setAnswerConfig');
 
+        component.questionIndex = 1;
         component.ngOnInit();
+        component.ngOnChanges({});
+
+        await jest.runAllTimers();
+
+        component.questionIndex = 2;
+        component.ngOnChanges({});
+
+        await jest.runAllTimers();
+
         component.config.get('equalCase')?.setValue(true);
 
         await jest.runAllTimers();
 
-        expect(setAnswerConfig).toHaveBeenCalledTimes(1);
-        expect(setAnswerConfig.mock.calls[0][0].equalCase).toEqual(true);
+        expect(setAnswerConfig).toBeCalledTimes(1);
+        expect(setAnswerConfig.mock.calls[0][1].equalCase).toEqual(true);
       });
     });
 
@@ -148,8 +336,6 @@ describe('AnswerInputComponent', () => {
       let mockQuestionPair: QuestionPair;
 
       beforeEach(() => {
-        jest.useFakeTimers();
-
         mockQuestionPair = {
           answer: { answer: [], answerTo: 'question id', config: { equalCase: false } },
           question: {
@@ -158,16 +344,19 @@ describe('AnswerInputComponent', () => {
             id: 'question id',
             type: 'WRITE_ANSWER',
           },
+          index: 0,
         };
       });
 
       it('should update form if related config changed', async () => {
         mockQuestionPair.answer.config.equalCase = true;
         const subject = new Subject();
-        const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-        getCurrentQuestion.mockReturnValue(subject as any);
+        const getQuestion = jest.spyOn(service, 'getQuestion');
+        getQuestion.mockReturnValue(subject as any);
 
+        component.questionIndex = 1;
         component.ngOnInit();
+        component.ngOnChanges({});
         subject.next(_.cloneDeep(mockQuestionPair));
 
         await jest.runAllTimers();
@@ -185,10 +374,12 @@ describe('AnswerInputComponent', () => {
         mockQuestionPair.answer.config.equalCase = true;
 
         const subject = new Subject();
-        const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-        getCurrentQuestion.mockReturnValue(subject as any);
+        const getQuestion = jest.spyOn(service, 'getQuestion');
+        getQuestion.mockReturnValue(subject as any);
 
+        component.questionIndex = 1;
         component.ngOnInit();
+        component.ngOnChanges({});
         subject.next(_.cloneDeep(mockQuestionPair));
 
         await jest.runAllTimers();

--- a/src/app/editor/settings/answer-options/one-true/one-true.component.html
+++ b/src/app/editor/settings/answer-options/one-true/one-true.component.html
@@ -1,10 +1,9 @@
 <app-setting-card>
   <app-setting-card-title
     title="Answer options"
-    checkErrors="forCurrentQuestion"
+    checkErrors="forQuestion"
     path="question.answerOptions"
-    checkErrors="forCurrentQuestion"
-    path="question.answerOptions"
+    [questionIndex]="questionIndex"
   >
     <span
       fxFlex

--- a/src/app/editor/settings/answer-options/one-true/one-true.component.spec.ts
+++ b/src/app/editor/settings/answer-options/one-true/one-true.component.spec.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { Subject } from 'rxjs';
 import { QuizeeEditingService } from 'src/app/editor/quizee-editing.service';
 
 import { OneTrueComponent } from './one-true.component';
@@ -18,12 +19,55 @@ describe('OneTrueComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call subscribeToUpdates', () => {
-    const subscribeToUpdates = jest.spyOn(component, 'subscribeToUpdates');
+  describe('onChanges', () => {
+    it('should call `subscribeToUpdates` with provided question index', () => {
+      const subscribeToUpdates = jest.spyOn(component, 'subscribeToUpdates');
 
-    component.ngOnInit();
+      component.questionIndex = 1;
+      component.ngOnChanges({});
 
-    expect(subscribeToUpdates).toBeCalledTimes(1);
+      expect(subscribeToUpdates).toBeCalledTimes(1);
+      expect(subscribeToUpdates).toBeCalledWith(service, 1);
+    });
+
+    it('should not call `subscribeToUpdates` if question index is negative', () => {
+      const subscribeToUpdates = jest.spyOn(component, 'subscribeToUpdates');
+
+      component.questionIndex = -1;
+      component.ngOnChanges({});
+
+      expect(subscribeToUpdates).not.toBeCalled();
+    });
+
+    it('should unsubscribe if question index is negative', async () => {
+      const subject = new Subject();
+      const subscribeToUpdates = jest.spyOn(component, 'subscribeToUpdates').mockReturnValue(subject as any);
+
+      component.questionIndex = 1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+      subscribeToUpdates.mockReset();
+
+      component.questionIndex = -1;
+      component.ngOnChanges({});
+
+      expect(subject.observed).toBeFalsy();
+    });
+
+    it('should unsubscribe from previous subscription', async () => {
+      const subject = new Subject();
+      const subscribeToUpdates = jest.spyOn(component, 'subscribeToUpdates').mockReturnValue(subject as any);
+
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+      subscribeToUpdates.mockReset();
+
+      component.ngOnChanges({});
+
+      expect(subject.observed).toBeFalsy();
+    });
   });
 
   describe('remove answer option', () => {
@@ -37,48 +81,70 @@ describe('OneTrueComponent', () => {
       expect(removeAnswerOption).not.toHaveBeenCalled();
     });
 
-    it('should prompt service to remove answer option with provided id', async () => {
+    it('should prompt service to remove answer option with provided id in provided question', async () => {
       const removeAnswerOption = jest.spyOn(service, 'removeAnswerOption');
       component.controls = [
         { id: '1', control: {} as any },
         { id: '2', control: {} as any },
       ];
+
+      component.questionIndex = 1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
       component.removeAnswerOption('1');
 
       await jest.runAllTimers();
 
-      expect(removeAnswerOption).toHaveBeenCalledTimes(1);
-      expect(removeAnswerOption).toHaveBeenCalledWith('1');
+      expect(removeAnswerOption).toBeCalledTimes(1);
+      expect(removeAnswerOption).toBeCalledWith(1, '1');
     });
   });
 
   describe('createAnswerOption', () => {
-    it('should prompt service to create answer option', async () => {
+    it('should prompt service to create answer option for provided question', async () => {
       const addAnswerOption = jest.spyOn(service, 'addAnswerOption');
+
+      component.questionIndex = 1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
       component.createAnswerOption();
 
       await jest.runAllTimers();
 
-      expect(addAnswerOption).toHaveBeenCalledTimes(1);
+      expect(addAnswerOption).toBeCalledTimes(1);
+      expect(addAnswerOption).toBeCalledWith(1);
     });
   });
 
   describe('setAnswer', () => {
-    it('should allow only one correct answer', () => {
+    it('should allow only one correct answer', async () => {
       component.setAnswer('1');
       component.setAnswer('2');
       component.setAnswer('3');
 
+      await jest.runAllTimers();
+
       expect(component.correctAnswers).toEqual(['3']);
     });
 
-    it('should push answer to service', () => {
+    it('should push answer to service', async () => {
       const setAnswer = jest.spyOn(service, 'setAnswer');
+
+      component.questionIndex = 1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
 
       component.setAnswer('1');
 
+      await jest.runAllTimers();
+
       expect(setAnswer).toBeCalledTimes(1);
-      expect(setAnswer).toBeCalledWith(['1']);
+      expect(setAnswer).toBeCalledWith(1, ['1']);
     });
   });
 });

--- a/src/app/editor/settings/answer-options/one-true/one-true.component.ts
+++ b/src/app/editor/settings/answer-options/one-true/one-true.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { AnswerOptionId } from '@di-strix/quizee-types';
 
 import * as _ from 'lodash';
@@ -12,33 +12,38 @@ import { SelectiveAnswersBase } from '../selective-answers-base.component';
   templateUrl: './one-true.component.html',
   styleUrls: ['./one-true.component.scss'],
 })
-export class OneTrueComponent extends SelectiveAnswersBase implements OnInit, OnDestroy {
+export class OneTrueComponent extends SelectiveAnswersBase implements OnDestroy, OnChanges {
   subs = new Subscription();
 
   constructor(private quizeeEditingService: QuizeeEditingService) {
     super();
   }
 
-  ngOnInit() {
-    this.subs.add(this.subscribeToUpdates(this.quizeeEditingService));
-  }
-
   ngOnDestroy() {
     this.subs.unsubscribe();
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    this.subs.unsubscribe();
+    this.subs = new Subscription();
+
+    if (this.questionIndex < 0) return;
+
+    this.subs.add(this.subscribeToUpdates(this.quizeeEditingService, this.questionIndex));
+  }
+
   setAnswer(id: AnswerOptionId) {
     this.correctAnswers = [id];
-    this.quizeeEditingService.setAnswer(this.assembleAnswers());
+    this.quizeeEditingService.setAnswer(this.questionIndex, this.assembleAnswers());
   }
 
   removeAnswerOption(id: AnswerOptionId) {
     if (this.controls.length <= 1) return;
 
-    this.quizeeEditingService.removeAnswerOption(id);
+    this.quizeeEditingService.removeAnswerOption(this.questionIndex, id);
   }
 
   createAnswerOption() {
-    this.quizeeEditingService.addAnswerOption();
+    this.quizeeEditingService.addAnswerOption(this.questionIndex);
   }
 }

--- a/src/app/editor/settings/answer-options/several-true/several-true.component.html
+++ b/src/app/editor/settings/answer-options/several-true/several-true.component.html
@@ -1,8 +1,9 @@
 <app-setting-card>
   <app-setting-card-title
     title="Answer options"
-    checkErrors="forCurrentQuestion"
+    checkErrors="forQuestion"
     path="question.answerOptions"
+    [questionIndex]="questionIndex"
   >
     <span
       fxFlex

--- a/src/app/editor/settings/answer-options/several-true/several-true.component.ts
+++ b/src/app/editor/settings/answer-options/several-true/several-true.component.ts
@@ -1,10 +1,8 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatCheckboxChange } from '@angular/material/checkbox';
-import { AnswerOption, AnswerOptionId } from '@di-strix/quizee-types';
+import { Component, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { AnswerOptionId } from '@di-strix/quizee-types';
 
 import * as _ from 'lodash';
-import { Subscription, filter } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { QuizeeEditingService } from 'src/app/editor/quizee-editing.service';
 
 import { SelectiveAnswersBase } from '../selective-answers-base.component';
@@ -21,34 +19,39 @@ export interface SeveralTrueAnswerOptionForm {
   templateUrl: './several-true.component.html',
   styleUrls: ['./several-true.component.scss'],
 })
-export class SeveralTrueComponent extends SelectiveAnswersBase implements OnInit, OnDestroy {
+export class SeveralTrueComponent extends SelectiveAnswersBase implements OnDestroy, OnChanges {
   subs = new Subscription();
 
   constructor(public quizeeEditingService: QuizeeEditingService) {
     super();
   }
 
-  ngOnInit(): void {
-    this.subs.add(this.subscribeToUpdates(this.quizeeEditingService));
-  }
-
   ngOnDestroy(): void {
     this.subs.unsubscribe();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.subs.unsubscribe();
+    this.subs = new Subscription();
+
+    if (this.questionIndex < 0) return;
+
+    this.subs.add(this.subscribeToUpdates(this.quizeeEditingService, this.questionIndex));
   }
 
   setAnswer(id: AnswerOptionId) {
     this.correctAnswers = _.xor(this.correctAnswers, [id]);
 
-    this.quizeeEditingService.setAnswer(this.assembleAnswers());
+    this.quizeeEditingService.setAnswer(this.questionIndex, this.assembleAnswers());
   }
 
   removeAnswerOption(id: AnswerOptionId) {
     if (this.controls.length <= 1) return;
 
-    this.quizeeEditingService.removeAnswerOption(id);
+    this.quizeeEditingService.removeAnswerOption(this.questionIndex, id);
   }
 
   createAnswerOption() {
-    this.quizeeEditingService.addAnswerOption();
+    this.quizeeEditingService.addAnswerOption(this.questionIndex);
   }
 }

--- a/src/app/editor/settings/question-caption/question-caption.component.html
+++ b/src/app/editor/settings/question-caption/question-caption.component.html
@@ -1,8 +1,9 @@
 <app-setting-card>
   <app-setting-card-title
     title="Question caption"
-    checkErrors="forCurrentQuestion"
+    checkErrors="forQuestion"
     path="question.caption"
+    [questionIndex]="questionIndex"
   >
   </app-setting-card-title>
   <app-setting-card-content>

--- a/src/app/editor/settings/question-caption/question-caption.component.spec.ts
+++ b/src/app/editor/settings/question-caption/question-caption.component.spec.ts
@@ -1,14 +1,21 @@
 import { Subject, of } from 'rxjs';
 
 import { QuizeeEditingService } from '../../quizee-editing.service';
+import { QuizeeValidators } from '../../quizee-validators';
 
 import { QuestionCaptionComponent } from './question-caption.component';
+
+jest.mock('../../quizee-validators');
 
 describe('QuestionCaptionComponent', () => {
   let component: QuestionCaptionComponent;
   let service: QuizeeEditingService;
+  let forQuestion: jest.Mock;
 
   beforeEach(() => {
+    forQuestion = jest.fn().mockReturnValue(() => of());
+    (QuizeeValidators.forQuestion as jest.Mock).mockImplementation((...args: any[]) => forQuestion(...args));
+
     service = new QuizeeEditingService();
     component = new QuestionCaptionComponent(service);
 
@@ -19,70 +26,245 @@ describe('QuestionCaptionComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should subscribe to current question', async () => {
-    const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-    getCurrentQuestion.mockReturnValue(of());
+  describe('onInit', () => {
+    it('should not subscribe', async () => {
+      jest.spyOn(service, 'getCurrentQuestion').mockReturnValue(of());
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      component.ngOnInit();
 
-    component.ngOnInit();
+      await jest.runAllTimers();
 
-    await jest.runAllTimers();
+      expect(service.getCurrentQuestion).not.toBeCalled();
+      expect(service.getQuestion).not.toBeCalled();
+    });
 
-    expect(getCurrentQuestion).toHaveBeenCalled();
+    it('should mark input as touched', async () => {
+      component.ngOnInit();
+
+      await jest.runAllTimers();
+
+      expect(component.questionCaption.touched).toBeTruthy();
+    });
+  });
+
+  describe('onChanges', () => {
+    it('should subscribe on question with provided index', async () => {
+      const subject = new Subject();
+      jest.spyOn(service, 'getQuestion').mockReturnValue(subject as any);
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject.observed).toBeTruthy();
+    });
+
+    it('should unsubscribe from previous question', async () => {
+      const subject = new Subject();
+      const getQuestion = jest.spyOn(service, 'getQuestion').mockReturnValue(subject as any);
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      getQuestion.mockReset();
+      getQuestion.mockReturnValue(of());
+
+      component.questionIndex = 2;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject.observed).toBeFalsy();
+    });
+
+    it('should subscribe to new question with provided index', async () => {
+      const subject = new Subject();
+      const getQuestion = jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      getQuestion.mockReset();
+      getQuestion.mockReturnValue(subject as any);
+
+      component.questionIndex = 2;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject.observed).toBeTruthy();
+    });
+
+    it('should not subscribe if provided index is negative', async () => {
+      const subject1 = new Subject();
+      const subject2 = new Subject();
+      const getQuestion = jest.spyOn(service, 'getQuestion').mockReturnValue(subject1 as any);
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      getQuestion.mockReset();
+      getQuestion.mockReturnValue(subject2 as any);
+
+      component.questionIndex = -1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(subject1.observed).toBeFalsy();
+      expect(subject2.observed).toBeFalsy();
+    });
+
+    it('should clear async validators on question index change', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const clearAsyncValidators = jest.spyOn(component.questionCaption, 'clearAsyncValidators');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      component.questionIndex = 0;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(clearAsyncValidators).toBeCalled();
+    });
+
+    it('should clear async validators if new question index is negative', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const clearAsyncValidators = jest.spyOn(component.questionCaption, 'clearAsyncValidators');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      component.questionIndex = -1;
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(clearAsyncValidators).toBeCalled();
+    });
+
+    it('should set async validators with validators for new question', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const subject = new Subject();
+      const validatorFn = jest.fn().mockReturnValue(subject);
+      forQuestion.mockReturnValue(validatorFn);
+      const setAsyncValidators = jest.spyOn(component.questionCaption, 'setAsyncValidators');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(forQuestion.mock.calls[0][1]).toEqual(1);
+      expect(setAsyncValidators).toBeCalledWith([validatorFn]);
+    });
+
+    it('should update validity after validators set', async () => {
+      jest.spyOn(service, 'getQuestion').mockReturnValue(of());
+      const updateValueAndValidity = jest.spyOn(component.questionCaption, 'updateValueAndValidity');
+
+      component.questionIndex = 1;
+      component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
+      expect(updateValueAndValidity).toBeCalledWith({ emitEvent: false });
+    });
   });
 
   describe('input value change', () => {
-    it('should update quizee on input value change', async () => {
-      const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-      getCurrentQuestion.mockReturnValue(of({ question: { caption: '' } } as any));
+    it('should update provided question on input value change', async () => {
+      const getQuestion = jest.spyOn(service, 'getQuestion');
+      getQuestion.mockReturnValue(of({ question: { caption: '' } } as any));
 
-      const modifyCurrentQuestion = jest.spyOn(service, 'modifyCurrentQuestion');
+      const modifyQuestion = jest.spyOn(service, 'modifyQuestion');
 
+      component.questionIndex = 1;
       component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
       component.questionCaption.setValue('abc');
 
       await jest.runAllTimers();
 
-      expect(modifyCurrentQuestion).toHaveBeenCalledTimes(1);
-      expect(modifyCurrentQuestion).toHaveBeenCalledWith({ question: { caption: 'abc' } });
+      expect(modifyQuestion).toBeCalledTimes(1);
+      expect(modifyQuestion).toBeCalledWith(1, { question: { caption: 'abc' } });
     });
   });
 
   describe('question caption value change', () => {
     it('should update input value if its value differs', async () => {
       const subject = new Subject();
-      const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-      getCurrentQuestion.mockReturnValue(subject as any);
+      const getQuestion = jest.spyOn(service, 'getQuestion');
+      getQuestion.mockReturnValue(subject as any);
 
       const setValue = jest.spyOn(component.questionCaption, 'setValue');
 
+      component.questionIndex = 1;
       component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
       subject.next({ question: { caption: 'abc' } });
 
       await jest.runAllTimers();
 
       subject.next({ question: { caption: 'abc123' } });
 
+      await jest.runAllTimers();
+
       expect(setValue).toBeCalledTimes(2);
-      expect(setValue.mock.calls[0][0]).toBe('abc');
-      expect(setValue.mock.calls[1][0]).toBe('abc123');
+      expect(setValue).toHaveBeenNthCalledWith(1, 'abc');
+      expect(setValue).toHaveBeenNthCalledWith(2, 'abc123');
     });
 
     it('should not update input value if it is the same', async () => {
       const subject = new Subject();
-      const getCurrentQuestion = jest.spyOn(service, 'getCurrentQuestion');
-      getCurrentQuestion.mockReturnValue(subject as any);
+      const getQuestion = jest.spyOn(service, 'getQuestion');
+      getQuestion.mockReturnValue(subject as any);
 
       const setValue = jest.spyOn(component.questionCaption, 'setValue');
 
+      component.questionIndex = 1;
       component.ngOnInit();
+      component.ngOnChanges({});
+
+      await jest.runAllTimers();
+
       subject.next({ question: { caption: 'abc' } });
 
       await jest.runAllTimers();
 
       subject.next({ question: { caption: 'abc' } });
 
+      await jest.runAllTimers();
+
       expect(setValue).toBeCalledTimes(1);
-      expect(setValue.mock.calls[0][0]).toBe('abc');
+      expect(setValue).toHaveBeenNthCalledWith(1, 'abc');
     });
   });
 });

--- a/src/app/editor/settings/setting-card/setting-card-title/setting-card-title.component.ts
+++ b/src/app/editor/settings/setting-card/setting-card-title/setting-card-title.component.ts
@@ -1,6 +1,7 @@
 import { animate, style, transition, trigger } from '@angular/animations';
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 
+import * as _ from 'lodash';
 import { Subscription, from } from 'rxjs';
 import { QuizeeEditingService } from 'src/app/editor/quizee-editing.service';
 import { QuizeeValidators } from 'src/app/editor/quizee-validators';
@@ -16,9 +17,10 @@ import { QuizeeValidators } from 'src/app/editor/quizee-validators';
     ]),
   ],
 })
-export class SettingCardTitleComponent implements OnInit, OnDestroy {
+export class SettingCardTitleComponent implements OnDestroy, OnChanges {
   @Input() title: string = '';
-  @Input() checkErrors!: 'forQuizee' | 'forCurrentQuestion';
+  @Input() checkErrors!: 'forQuizee' | 'forQuestion';
+  @Input() questionIndex: number = -1;
   @Input() path!: string;
 
   subs = new Subscription();
@@ -26,18 +28,29 @@ export class SettingCardTitleComponent implements OnInit, OnDestroy {
 
   constructor(private quizeeEditingService: QuizeeEditingService) {}
 
-  ngOnInit(): void {
-    if (this.checkErrors) {
-      if (!this.path) throw new Error('Path must be specified once checkErrors is set');
-      this.subs.add(
-        from(QuizeeValidators[this.checkErrors](this.quizeeEditingService, this.path, false)(null as any)).subscribe(
-          (errors) => (this.error = !!errors)
-        )
-      );
-    }
-  }
-
   ngOnDestroy() {
     this.subs.unsubscribe();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.updateValidators();
+  }
+
+  updateValidators() {
+    this.subs.unsubscribe();
+    this.subs = new Subscription();
+
+    if (this.checkErrors) {
+      if (!this.path) throw new Error('Path must be specified once checkErrors is set');
+
+      let validator;
+      if (this.checkErrors === 'forQuestion' && this.questionIndex >= 0)
+        validator = QuizeeValidators.forQuestion(this.quizeeEditingService, this.questionIndex, this.path, false);
+      else if (this.checkErrors === 'forQuestion')
+        validator = QuizeeValidators.forCurrentQuestion(this.quizeeEditingService, this.path, false);
+      else validator = QuizeeValidators[this.checkErrors](this.quizeeEditingService, this.path, false);
+
+      this.subs.add(from(validator(null as any) as any).subscribe((errors) => (this.error = !!errors)));
+    }
   }
 }

--- a/src/app/editor/settings/settings.component.ts
+++ b/src/app/editor/settings/settings.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 
-import { Subscription, distinctUntilKeyChanged } from 'rxjs';
+import { Observable, Subscription, distinctUntilKeyChanged } from 'rxjs';
 
 import { QuestionPair, QuizeeEditingService } from '../quizee-editing.service';
 
@@ -23,35 +23,51 @@ export const settingsConfig: SettingsConfig = {
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss'],
 })
-export class SettingsComponent implements OnInit, OnDestroy {
-  subs: Subscription = new Subscription();
+export class SettingsComponent implements OnInit, OnDestroy, OnChanges {
+  time = new Date();
+
+  @Input() questionIndex: number = -1;
+
+  questionSub: Subscription = new Subscription();
 
   @ViewChild(RenderSettingsComponentsDirective, { static: true }) container!: RenderSettingsComponentsDirective;
 
   constructor(public quizeeEditingService: QuizeeEditingService) {}
 
   ngOnInit(): void {
-    this.subs.add(
-      this.quizeeEditingService
-        .getCurrentQuestion()
-        .pipe(
-          distinctUntilKeyChanged(
-            'question',
-            (previous, current) => previous.id === current.id && previous.type === current.type
-          )
-        )
-        .subscribe((q: QuestionPair) => {
-          const containerRef = this.container.viewContainerRef;
-          containerRef.clear();
-
-          settingsConfig[q.question.type].forEach((c) => {
-            containerRef.createComponent(c);
-          });
-        })
-    );
+    this.updateQuestion();
   }
 
   ngOnDestroy(): void {
-    this.subs.unsubscribe();
+    this.questionSub.unsubscribe();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('questionIndex' in changes) this.updateQuestion();
+  }
+
+  updateQuestion() {
+    if (this.questionIndex < 0) this.loadQuestion(this.quizeeEditingService.getCurrentQuestion());
+    else this.loadQuestion(this.quizeeEditingService.getQuestion(this.questionIndex));
+  }
+
+  loadQuestion(questionStream: Observable<QuestionPair>): void {
+    this.questionSub.unsubscribe();
+
+    this.questionSub = questionStream
+      .pipe(
+        distinctUntilKeyChanged('question', (previous, current) => {
+          return previous.id === current.id && previous.type === current.type;
+        })
+      )
+      .subscribe((q: QuestionPair) => {
+        const containerRef = this.container.viewContainerRef;
+        containerRef.clear();
+
+        settingsConfig[q.question.type].forEach((c) => {
+          const component = containerRef.createComponent(c);
+          component.setInput('questionIndex', q.index);
+        });
+      });
   }
 }

--- a/src/app/shared/decorators/AutoDispatchEvent.spec.ts
+++ b/src/app/shared/decorators/AutoDispatchEvent.spec.ts
@@ -13,6 +13,11 @@ class TestClass {
     return of();
   }
 
+  @AutoDispatchEvent(['dispatcher'])
+  callNested(): Observable<any> {
+    return this.someNestedFunction();
+  }
+
   @RegisterDispatcher()
   dispatcher() {}
 }
@@ -61,12 +66,12 @@ describe('AutoDispatchEvent', () => {
   it('should call dispatcher only once even if nested functions are registered for auto dispatch', () => {
     const dispatcher = jest.spyOn(testClass, 'dispatcher');
     const someNestedFunction = jest.spyOn(testClass, 'someNestedFunction');
-    const someFunction = jest.spyOn(testClass, 'someFunction').mockImplementation(() => testClass.someNestedFunction());
+    const callNested = jest.spyOn(testClass, 'callNested');
 
-    testClass.someFunction();
+    testClass.callNested();
 
     expect(dispatcher).toBeCalledTimes(1);
-    expect(someFunction).toBeCalledTimes(1);
+    expect(callNested).toBeCalledTimes(1);
     expect(someNestedFunction).toBeCalledTimes(1);
   });
 

--- a/src/app/shared/decorators/AutoDispatchEvent.ts
+++ b/src/app/shared/decorators/AutoDispatchEvent.ts
@@ -15,13 +15,6 @@ const setEntry = (target: any, key: string) => (target[configKey].entry = key);
 /**
  * Calls provided dispatchers after function execution.
  *
- * ---
- *
- * Wraps function into try-catch so dispatchers won't be called if any error occurs.
- * Transforms error `throwError()` rxjs function
- *
- * ---
- *
  * #### To prevent dispatchers from being invoked, simply throw an exception
  *
  * ---
@@ -51,7 +44,7 @@ export const AutoDispatchEvent = (callDispatchers: string[]) => {
           } catch (err) {
             clearEntry(target);
 
-            return throwError(() => err);
+            throw err;
           }
         };
       }

--- a/src/app/shared/decorators/ErrorAsStream.spec.ts
+++ b/src/app/shared/decorators/ErrorAsStream.spec.ts
@@ -1,0 +1,87 @@
+import { Observable, of } from 'rxjs';
+
+import { ErrorAsStream } from './ErrorAsStream';
+
+class TestClass {
+  testValue: string = '';
+
+  @ErrorAsStream()
+  test(throwError: boolean): Observable<string> {
+    if (throwError) throw new Error('Some error');
+
+    return of('No error');
+  }
+
+  @ErrorAsStream()
+  testContext(): Observable<string> {
+    return of(this.testValue);
+  }
+
+  @ErrorAsStream()
+  testArgs(...args: any[]): Observable<any> {
+    return of([...args]);
+  }
+}
+
+describe('ExceptionAsStream', () => {
+  let testClass: TestClass;
+
+  beforeEach(() => {
+    testClass = new TestClass();
+
+    jest.useFakeTimers();
+  });
+
+  it('should catch thrown exception', async () => {
+    expect(() => testClass.test(true)).not.toThrow();
+  });
+
+  it('should transform thrown error to rxjs stream', async () => {
+    const next = jest.fn();
+    const error = jest.fn();
+
+    testClass.test(true).subscribe({ next, error });
+
+    await jest.runAllTimers();
+
+    expect(next).not.toBeCalled();
+    expect(error).toBeCalled();
+  });
+
+  it('should return original value if no error', async () => {
+    const next = jest.fn();
+    const error = jest.fn();
+
+    testClass.test(false).subscribe({ next, error });
+
+    await jest.runAllTimers();
+
+    expect(error).not.toBeCalled();
+    expect(next).toBeCalledWith('No error');
+  });
+
+  it('should call target function within its context', async () => {
+    const next = jest.fn();
+    const error = jest.fn();
+
+    testClass.testValue = '123';
+    testClass.testContext().subscribe({ next, error });
+
+    await jest.runAllTimers();
+
+    expect(error).not.toBeCalled();
+    expect(next).toBeCalledWith('123');
+  });
+
+  it('should call target function with provided args', async () => {
+    const next = jest.fn();
+    const error = jest.fn();
+
+    testClass.testArgs(1, 2, 3).subscribe({ next, error });
+
+    await jest.runAllTimers();
+
+    expect(error).not.toBeCalled();
+    expect(next).toBeCalledWith([1, 2, 3]);
+  });
+});

--- a/src/app/shared/decorators/ErrorAsStream.ts
+++ b/src/app/shared/decorators/ErrorAsStream.ts
@@ -1,0 +1,22 @@
+import { Observable, throwError } from 'rxjs';
+
+/**
+ * Transforms thrown errors rxjs stream using `throwError`
+ */
+export const ErrorAsStream = () => {
+  return (
+    target: any,
+    propertyKey: string,
+    descriptor: TypedPropertyDescriptor<(...args: any[]) => Observable<any>>
+  ) => {
+    const fn = descriptor.value as Function;
+
+    descriptor.value = function (this: any, ...args: any[]) {
+      try {
+        return fn.apply(this, args);
+      } catch (err) {
+        return throwError(() => err);
+      }
+    };
+  };
+};


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Other

## What is the current behavior?
### (You can also link to an open issue here)
Quizee editor is ugly and not usable on mobile devices.

## What is the new behavior?
Quizee editor can be now  used conveniently on mobile devices.

## Does this PR introduce a breaking change?
The `QuizeeEditingService` was rewritten to meet new `index-based` concept. Before, all modifications were applied to the current question (`current-question` concept) which was greatly limiting functionality and flexibility of the service and editor as well.
Since this PR `QuizeeEditingService` follows new  `index-based` concept where all the modifications are done to questions under specified index. Functions that perform modifications over current question are present too, but now they're shortcuts to the `index-based` functions.

`AutoDispatchEvent` decorator no more transforms thrown errors to rxjs stream errors since this might cause confusion. Instead, `ErrorAsStream` was introduced to cover this need.

## Other information